### PR TITLE
refactor: inject telemetry into HermesAgentReconciler instead of global variable

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -37,6 +37,7 @@ import (
 
 	agentsv1alpha1 "hermeum/hermes-agent-operator/api/v1alpha1"
 	"hermeum/hermes-agent-operator/internal/controller"
+	"hermeum/hermes-agent-operator/internal/infras"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -178,9 +179,12 @@ func main() {
 		os.Exit(1)
 	}
 
+	tel := infras.NewPrometheusTelemetry()
+
 	if err := (&controller.HermesAgentReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Telemetry: tel,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "Failed to create controller", "controller", "hermesagent")
 		os.Exit(1)

--- a/internal/controller/hermesagent_controller.go
+++ b/internal/controller/hermesagent_controller.go
@@ -31,13 +31,11 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// telemetry is the Telemetry implementation used by Reconcile.
-var telemetry usecase.Telemetry = infras.NewPrometheusTelemetry()
-
 // HermesAgentReconciler reconciles a HermesAgent object
 type HermesAgentReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme    *runtime.Scheme
+	Telemetry usecase.Telemetry
 }
 
 // +kubebuilder:rbac:groups=agents.hermeum.app,resources=hermesagents,verbs=get;list;watch;create;update;patch;delete
@@ -56,7 +54,7 @@ type HermesAgentReconciler struct {
 
 func (r *HermesAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	kube := infras.NewKubernetesClient(r.Client, r.Scheme)
-	uc := usecase.NewHermesAgentUseCase(kube, telemetry)
+	uc := usecase.NewHermesAgentUseCase(kube, r.Telemetry)
 	result, err := uc.Reconcile(ctx, usecase.ReconcileParam{
 		NamespacedName: req.NamespacedName,
 	})


### PR DESCRIPTION
## Summary

- Removes the package-level `var telemetry usecase.Telemetry` global from `internal/controller/hermesagent_controller.go`
- Adds a `Telemetry usecase.Telemetry` field to `HermesAgentReconciler`, following the same DI pattern already used for `Client` and `Scheme`
- Constructs `infras.NewPrometheusTelemetry()` in `cmd/main.go` and passes it when registering the controller

## Why

The global variable coupled the controller package to a concrete Prometheus implementation at init time, making it harder to substitute alternative implementations (e.g. in tests) without monkey-patching a package-level var.

## Test plan

- [x] `go build ./...` passes
- [x] `make lint-fix` reports 0 issues
- [x] Deploy to a cluster and confirm reconciliation metrics are still emitted

🤖 Generated with [Claude Code](https://claude.com/claude-code)