### PR TITLE
refactor: centralize error logging and reconcile metrics in `Reconcile` method

### DIFF
--- a/internal/usecase/hermesagent.go
+++ b/internal/usecase/hermesagent.go
@@ -30,7 +30,7 @@ func NewHermesAgentUseCase(kube Kubernetes, tel Telemetry) *HermesAgentUseCase {
 	}
 }
 
-func (u *HermesAgentUseCase) Reconcile(ctx context.Context, param ReconcileParam) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) Reconcile(ctx context.Context, param ReconcileParam) (ctrl.Result, error) { //nolint:gocyclo
 	start := time.Now()
 	defer func() {
 		u.tel.ObserveReconcileDuration(ctx, ObserveReconcileDurationParam{

--- a/internal/usecase/hermesagent.go
+++ b/internal/usecase/hermesagent.go
@@ -58,73 +58,33 @@ func (u *HermesAgentUseCase) Reconcile(ctx context.Context, param ReconcileParam
 	ha.Status.ManagedResources = agentsv1alpha1.ManagedResources{}
 
 	if result, err := u.reconcileHermesConfigMap(ctx, ha); err != nil || !result.IsZero() {
-		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile Hermes ConfigMap", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
-		}
 		return result, err
 	}
 	if result, err := u.reconcileHermesSecret(ctx, ha); err != nil || !result.IsZero() {
-		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile Hermes Secret", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
-		}
 		return result, err
 	}
 	if result, err := u.reconcileSearXNGConfigMap(ctx, ha); err != nil || !result.IsZero() {
-		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile SearXNG ConfigMap", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
-		}
 		return result, err
 	}
 	if result, err := u.reconcileSearXNGSecret(ctx, ha); err != nil || !result.IsZero() {
-		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile SearXNG Secret", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
-		}
 		return result, err
 	}
 	if result, err := u.reconcileServiceAccount(ctx, ha); err != nil || !result.IsZero() {
-		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile ServiceAccount", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
-		}
 		return result, err
 	}
 	if result, err := u.reconcileRole(ctx, ha); err != nil || !result.IsZero() {
-		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile Role", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
-		}
 		return result, err
 	}
 	if result, err := u.reconcileService(ctx, ha); err != nil || !result.IsZero() {
-		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile Service", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
-		}
 		return result, err
 	}
 	if result, err := u.reconcileIngress(ctx, ha); err != nil || !result.IsZero() {
-		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile Ingress", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
-		}
 		return result, err
 	}
 	if result, err := u.reconcileNetworkPolicy(ctx, ha); err != nil || !result.IsZero() {
-		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile NetworkPolicy", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
-		}
 		return result, err
 	}
 	if result, err := u.reconcileStatefulSet(ctx, ha); err != nil || !result.IsZero() {
-		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile StatefulSet", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
-		}
 		return result, err
 	}
 

--- a/internal/usecase/hermesagent.go
+++ b/internal/usecase/hermesagent.go
@@ -58,33 +58,73 @@ func (u *HermesAgentUseCase) Reconcile(ctx context.Context, param ReconcileParam
 	ha.Status.ManagedResources = agentsv1alpha1.ManagedResources{}
 
 	if result, err := u.reconcileHermesConfigMap(ctx, ha); err != nil || !result.IsZero() {
+		if err != nil {
+			u.tel.Error(ctx, err, "Failed to reconcile Hermes ConfigMap", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
+		}
 		return result, err
 	}
 	if result, err := u.reconcileHermesSecret(ctx, ha); err != nil || !result.IsZero() {
+		if err != nil {
+			u.tel.Error(ctx, err, "Failed to reconcile Hermes Secret", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
+		}
 		return result, err
 	}
 	if result, err := u.reconcileSearXNGConfigMap(ctx, ha); err != nil || !result.IsZero() {
+		if err != nil {
+			u.tel.Error(ctx, err, "Failed to reconcile SearXNG ConfigMap", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
+		}
 		return result, err
 	}
 	if result, err := u.reconcileSearXNGSecret(ctx, ha); err != nil || !result.IsZero() {
+		if err != nil {
+			u.tel.Error(ctx, err, "Failed to reconcile SearXNG Secret", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
+		}
 		return result, err
 	}
 	if result, err := u.reconcileServiceAccount(ctx, ha); err != nil || !result.IsZero() {
+		if err != nil {
+			u.tel.Error(ctx, err, "Failed to reconcile ServiceAccount", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
+		}
 		return result, err
 	}
 	if result, err := u.reconcileRole(ctx, ha); err != nil || !result.IsZero() {
+		if err != nil {
+			u.tel.Error(ctx, err, "Failed to reconcile Role", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
+		}
 		return result, err
 	}
 	if result, err := u.reconcileService(ctx, ha); err != nil || !result.IsZero() {
+		if err != nil {
+			u.tel.Error(ctx, err, "Failed to reconcile Service", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
+		}
 		return result, err
 	}
 	if result, err := u.reconcileIngress(ctx, ha); err != nil || !result.IsZero() {
+		if err != nil {
+			u.tel.Error(ctx, err, "Failed to reconcile Ingress", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
+		}
 		return result, err
 	}
 	if result, err := u.reconcileNetworkPolicy(ctx, ha); err != nil || !result.IsZero() {
+		if err != nil {
+			u.tel.Error(ctx, err, "Failed to reconcile NetworkPolicy", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
+		}
 		return result, err
 	}
 	if result, err := u.reconcileStatefulSet(ctx, ha); err != nil || !result.IsZero() {
+		if err != nil {
+			u.tel.Error(ctx, err, "Failed to reconcile StatefulSet", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
+		}
 		return result, err
 	}
 

--- a/internal/usecase/hermesagent_hermes_configmap.go
+++ b/internal/usecase/hermesagent_hermes_configmap.go
@@ -23,11 +23,15 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 		NamespacedName: types.NamespacedName{Name: cmName, Namespace: ha.Namespace},
 	})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get Hermes ConfigMap", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
 	desired, err := buildHermesConfigMap(ha)
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to build Hermes ConfigMap", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -36,6 +40,8 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 		err := u.kube.UpdateConfigMapOwnedByHermesAgent(ctx, UpdateConfigMapParam{HermesAgent: ha, ConfigMap: desired})
 		u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to update Hermes ConfigMap", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Hermes ConfigMap updated", "namespacedName", nsName)
@@ -46,6 +52,8 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 	err = u.kube.CreateConfigMapOwnedByHermesAgent(ctx, CreateConfigMapOfHermesAgentParam{HermesAgent: ha, ConfigMap: desired})
 	u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to create Hermes ConfigMap", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "Hermes ConfigMap created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_hermes_configmap.go
+++ b/internal/usecase/hermesagent_hermes_configmap.go
@@ -23,15 +23,11 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 		NamespacedName: types.NamespacedName{Name: cmName, Namespace: ha.Namespace},
 	})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get Hermes ConfigMap", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
 	desired, err := buildHermesConfigMap(ha)
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to build Hermes ConfigMap", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -40,8 +36,6 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 		err := u.kube.UpdateConfigMapOwnedByHermesAgent(ctx, UpdateConfigMapParam{HermesAgent: ha, ConfigMap: desired})
 		u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to update Hermes ConfigMap", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Hermes ConfigMap updated", "namespacedName", nsName)
@@ -52,8 +46,6 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 	err = u.kube.CreateConfigMapOwnedByHermesAgent(ctx, CreateConfigMapOfHermesAgentParam{HermesAgent: ha, ConfigMap: desired})
 	u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to create Hermes ConfigMap", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "Hermes ConfigMap created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_hermes_secret.go
+++ b/internal/usecase/hermesagent_hermes_secret.go
@@ -36,8 +36,6 @@ func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agen
 
 	existing, err := u.kube.GetSecret(ctx, GetSecretParam{NamespacedName: secretNsName})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get Hermes Secret", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -49,15 +47,11 @@ func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agen
 
 	secret, err := buildHermesSecret(ha)
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to build Hermes Secret", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	err = u.kube.CreateSecretOwnedByHermesAgent(ctx, CreateSecretOfHermesAgentParam{HermesAgent: ha, Secret: secret})
 	u.tel.IncSecretOperation(ctx, IncSecretOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to create Hermes Secret", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "Hermes Secret created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_hermes_secret.go
+++ b/internal/usecase/hermesagent_hermes_secret.go
@@ -36,6 +36,8 @@ func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agen
 
 	existing, err := u.kube.GetSecret(ctx, GetSecretParam{NamespacedName: secretNsName})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get Hermes Secret", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -47,11 +49,15 @@ func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agen
 
 	secret, err := buildHermesSecret(ha)
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to build Hermes Secret", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	err = u.kube.CreateSecretOwnedByHermesAgent(ctx, CreateSecretOfHermesAgentParam{HermesAgent: ha, Secret: secret})
 	u.tel.IncSecretOperation(ctx, IncSecretOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to create Hermes Secret", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "Hermes Secret created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_ingress.go
+++ b/internal/usecase/hermesagent_ingress.go
@@ -18,6 +18,8 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 
 	existing, err := u.kube.GetIngress(ctx, GetIngressParam{NamespacedName: nsName})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get Ingress", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -29,6 +31,8 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 		err := u.kube.DeleteIngress(ctx, DeleteIngressParam{NamespacedName: nsName})
 		u.tel.IncIngressOperation(ctx, IncIngressOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to delete Ingress", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Ingress deleted", "namespacedName", nsName)
@@ -41,6 +45,8 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 		err := u.kube.UpdateIngressOwnedByHermesAgent(ctx, UpdateIngressParam{HermesAgent: ha, Ingress: desired})
 		u.tel.IncIngressOperation(ctx, IncIngressOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to update Ingress", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Ingress updated", "namespacedName", nsName)
@@ -51,6 +57,8 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 	err = u.kube.CreateIngressOwnedByHermesAgent(ctx, CreateIngressOfHermesAgentParam{HermesAgent: ha, Ingress: desired})
 	u.tel.IncIngressOperation(ctx, IncIngressOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to create Ingress", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "Ingress created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_ingress.go
+++ b/internal/usecase/hermesagent_ingress.go
@@ -18,8 +18,6 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 
 	existing, err := u.kube.GetIngress(ctx, GetIngressParam{NamespacedName: nsName})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get Ingress", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -31,8 +29,6 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 		err := u.kube.DeleteIngress(ctx, DeleteIngressParam{NamespacedName: nsName})
 		u.tel.IncIngressOperation(ctx, IncIngressOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to delete Ingress", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Ingress deleted", "namespacedName", nsName)
@@ -45,8 +41,6 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 		err := u.kube.UpdateIngressOwnedByHermesAgent(ctx, UpdateIngressParam{HermesAgent: ha, Ingress: desired})
 		u.tel.IncIngressOperation(ctx, IncIngressOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to update Ingress", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Ingress updated", "namespacedName", nsName)
@@ -57,8 +51,6 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 	err = u.kube.CreateIngressOwnedByHermesAgent(ctx, CreateIngressOfHermesAgentParam{HermesAgent: ha, Ingress: desired})
 	u.tel.IncIngressOperation(ctx, IncIngressOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to create Ingress", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "Ingress created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_networkpolicy.go
+++ b/internal/usecase/hermesagent_networkpolicy.go
@@ -21,8 +21,6 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 
 	existing, err := u.kube.GetNetworkPolicy(ctx, GetNetworkPolicyParam{NamespacedName: nsName})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get NetworkPolicy", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -34,8 +32,6 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 		err := u.kube.DeleteNetworkPolicy(ctx, DeleteNetworkPolicyParam{NamespacedName: nsName})
 		u.tel.IncNetworkPolicyOperation(ctx, IncNetworkPolicyOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to delete NetworkPolicy", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "NetworkPolicy deleted", "namespacedName", nsName)
@@ -48,8 +44,6 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 		err := u.kube.UpdateNetworkPolicyOwnedByHermesAgent(ctx, UpdateNetworkPolicyParam{HermesAgent: ha, NetworkPolicy: desired})
 		u.tel.IncNetworkPolicyOperation(ctx, IncNetworkPolicyOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to update NetworkPolicy", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "NetworkPolicy updated", "namespacedName", nsName)
@@ -60,8 +54,6 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 	err = u.kube.CreateNetworkPolicyOwnedByHermesAgent(ctx, CreateNetworkPolicyOfHermesAgentParam{HermesAgent: ha, NetworkPolicy: desired})
 	u.tel.IncNetworkPolicyOperation(ctx, IncNetworkPolicyOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to create NetworkPolicy", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "NetworkPolicy created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_networkpolicy.go
+++ b/internal/usecase/hermesagent_networkpolicy.go
@@ -21,6 +21,8 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 
 	existing, err := u.kube.GetNetworkPolicy(ctx, GetNetworkPolicyParam{NamespacedName: nsName})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get NetworkPolicy", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -32,6 +34,8 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 		err := u.kube.DeleteNetworkPolicy(ctx, DeleteNetworkPolicyParam{NamespacedName: nsName})
 		u.tel.IncNetworkPolicyOperation(ctx, IncNetworkPolicyOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to delete NetworkPolicy", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "NetworkPolicy deleted", "namespacedName", nsName)
@@ -44,6 +48,8 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 		err := u.kube.UpdateNetworkPolicyOwnedByHermesAgent(ctx, UpdateNetworkPolicyParam{HermesAgent: ha, NetworkPolicy: desired})
 		u.tel.IncNetworkPolicyOperation(ctx, IncNetworkPolicyOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to update NetworkPolicy", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "NetworkPolicy updated", "namespacedName", nsName)
@@ -54,6 +60,8 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 	err = u.kube.CreateNetworkPolicyOwnedByHermesAgent(ctx, CreateNetworkPolicyOfHermesAgentParam{HermesAgent: ha, NetworkPolicy: desired})
 	u.tel.IncNetworkPolicyOperation(ctx, IncNetworkPolicyOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to create NetworkPolicy", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "NetworkPolicy created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_role.go
+++ b/internal/usecase/hermesagent_role.go
@@ -17,10 +17,14 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 
 	existingRole, err := u.kube.GetRole(ctx, GetRoleParam{NamespacedName: nsName})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get Role", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	existingRB, err := u.kube.GetRoleBinding(ctx, GetRoleBindingParam{NamespacedName: nsName})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get RoleBinding", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -32,6 +36,8 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 			err := u.kube.DeleteRoleBinding(ctx, DeleteRoleBindingParam{NamespacedName: nsName})
 			u.tel.IncRoleBindingOperation(ctx, IncRoleBindingOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
+				u.tel.Error(ctx, err, "Failed to delete RoleBinding", "namespacedName", nsName)
+				u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
 			u.tel.Debug(ctx, "RoleBinding deleted", "namespacedName", nsName)
@@ -40,6 +46,8 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 			err := u.kube.DeleteRole(ctx, DeleteRoleParam{NamespacedName: nsName})
 			u.tel.IncRoleOperation(ctx, IncRoleOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
+				u.tel.Error(ctx, err, "Failed to delete Role", "namespacedName", nsName)
+				u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
 			u.tel.Debug(ctx, "Role deleted", "namespacedName", nsName)
@@ -53,6 +61,8 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		err := u.kube.UpdateRoleOwnedByHermesAgent(ctx, UpdateRoleParam{HermesAgent: ha, Role: desiredRole})
 		u.tel.IncRoleOperation(ctx, IncRoleOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to update Role", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Role updated", "namespacedName", nsName)
@@ -60,6 +70,8 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		err := u.kube.CreateRoleOwnedByHermesAgent(ctx, CreateRoleOfHermesAgentParam{HermesAgent: ha, Role: desiredRole})
 		u.tel.IncRoleOperation(ctx, IncRoleOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to create Role", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Role created", "namespacedName", nsName)
@@ -71,6 +83,8 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		err := u.kube.UpdateRoleBindingOwnedByHermesAgent(ctx, UpdateRoleBindingParam{HermesAgent: ha, RoleBinding: desiredRB})
 		u.tel.IncRoleBindingOperation(ctx, IncRoleBindingOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to update RoleBinding", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "RoleBinding updated", "namespacedName", nsName)
@@ -78,6 +92,8 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		err := u.kube.CreateRoleBindingOwnedByHermesAgent(ctx, CreateRoleBindingOfHermesAgentParam{HermesAgent: ha, RoleBinding: desiredRB})
 		u.tel.IncRoleBindingOperation(ctx, IncRoleBindingOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to create RoleBinding", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "RoleBinding created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_role.go
+++ b/internal/usecase/hermesagent_role.go
@@ -17,14 +17,10 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 
 	existingRole, err := u.kube.GetRole(ctx, GetRoleParam{NamespacedName: nsName})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get Role", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	existingRB, err := u.kube.GetRoleBinding(ctx, GetRoleBindingParam{NamespacedName: nsName})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get RoleBinding", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -36,8 +32,6 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 			err := u.kube.DeleteRoleBinding(ctx, DeleteRoleBindingParam{NamespacedName: nsName})
 			u.tel.IncRoleBindingOperation(ctx, IncRoleBindingOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
-				u.tel.Error(ctx, err, "Failed to delete RoleBinding", "namespacedName", nsName)
-				u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
 			u.tel.Debug(ctx, "RoleBinding deleted", "namespacedName", nsName)
@@ -46,8 +40,6 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 			err := u.kube.DeleteRole(ctx, DeleteRoleParam{NamespacedName: nsName})
 			u.tel.IncRoleOperation(ctx, IncRoleOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
-				u.tel.Error(ctx, err, "Failed to delete Role", "namespacedName", nsName)
-				u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
 			u.tel.Debug(ctx, "Role deleted", "namespacedName", nsName)
@@ -61,8 +53,6 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		err := u.kube.UpdateRoleOwnedByHermesAgent(ctx, UpdateRoleParam{HermesAgent: ha, Role: desiredRole})
 		u.tel.IncRoleOperation(ctx, IncRoleOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to update Role", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Role updated", "namespacedName", nsName)
@@ -70,8 +60,6 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		err := u.kube.CreateRoleOwnedByHermesAgent(ctx, CreateRoleOfHermesAgentParam{HermesAgent: ha, Role: desiredRole})
 		u.tel.IncRoleOperation(ctx, IncRoleOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to create Role", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Role created", "namespacedName", nsName)
@@ -83,8 +71,6 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		err := u.kube.UpdateRoleBindingOwnedByHermesAgent(ctx, UpdateRoleBindingParam{HermesAgent: ha, RoleBinding: desiredRB})
 		u.tel.IncRoleBindingOperation(ctx, IncRoleBindingOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to update RoleBinding", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "RoleBinding updated", "namespacedName", nsName)
@@ -92,8 +78,6 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		err := u.kube.CreateRoleBindingOwnedByHermesAgent(ctx, CreateRoleBindingOfHermesAgentParam{HermesAgent: ha, RoleBinding: desiredRB})
 		u.tel.IncRoleBindingOperation(ctx, IncRoleBindingOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to create RoleBinding", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "RoleBinding created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_searxng_configmap.go
+++ b/internal/usecase/hermesagent_searxng_configmap.go
@@ -18,8 +18,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 
 	existing, err := u.kube.GetConfigMap(ctx, GetConfigMapParam{NamespacedName: cmNsName})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get SearXNG ConfigMap", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -30,8 +28,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 		err := u.kube.DeleteConfigMap(ctx, DeleteConfigMapParam{NamespacedName: cmNsName})
 		u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to delete SearXNG ConfigMap", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "SearXNG ConfigMap deleted", "namespacedName", nsName)
@@ -44,8 +40,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 		err := u.kube.UpdateConfigMapOwnedByHermesAgent(ctx, UpdateConfigMapParam{HermesAgent: ha, ConfigMap: desired})
 		u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to update SearXNG ConfigMap", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "SearXNG ConfigMap updated", "namespacedName", nsName)
@@ -56,8 +50,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 	err = u.kube.CreateConfigMapOwnedByHermesAgent(ctx, CreateConfigMapOfHermesAgentParam{HermesAgent: ha, ConfigMap: desired})
 	u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to create SearXNG ConfigMap", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "SearXNG ConfigMap created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_searxng_configmap.go
+++ b/internal/usecase/hermesagent_searxng_configmap.go
@@ -18,6 +18,8 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 
 	existing, err := u.kube.GetConfigMap(ctx, GetConfigMapParam{NamespacedName: cmNsName})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get SearXNG ConfigMap", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -28,6 +30,8 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 		err := u.kube.DeleteConfigMap(ctx, DeleteConfigMapParam{NamespacedName: cmNsName})
 		u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to delete SearXNG ConfigMap", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "SearXNG ConfigMap deleted", "namespacedName", nsName)
@@ -40,6 +44,8 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 		err := u.kube.UpdateConfigMapOwnedByHermesAgent(ctx, UpdateConfigMapParam{HermesAgent: ha, ConfigMap: desired})
 		u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to update SearXNG ConfigMap", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "SearXNG ConfigMap updated", "namespacedName", nsName)
@@ -50,6 +56,8 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 	err = u.kube.CreateConfigMapOwnedByHermesAgent(ctx, CreateConfigMapOfHermesAgentParam{HermesAgent: ha, ConfigMap: desired})
 	u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to create SearXNG ConfigMap", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "SearXNG ConfigMap created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_searxng_secret.go
+++ b/internal/usecase/hermesagent_searxng_secret.go
@@ -20,6 +20,8 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 
 	existing, err := u.kube.GetSecret(ctx, GetSecretParam{NamespacedName: secretNsName})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get SearXNG Secret", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -30,6 +32,8 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 		err := u.kube.DeleteSecret(ctx, DeleteSecretParam{NamespacedName: secretNsName})
 		u.tel.IncSecretOperation(ctx, IncSecretOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to delete SearXNG Secret", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "SearXNG Secret deleted", "namespacedName", nsName)
@@ -44,11 +48,15 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 
 	secret, err := buildSearXNGSecret(ha)
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to build SearXNG Secret", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	err = u.kube.CreateSecretOwnedByHermesAgent(ctx, CreateSecretOfHermesAgentParam{HermesAgent: ha, Secret: secret})
 	u.tel.IncSecretOperation(ctx, IncSecretOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to create SearXNG Secret", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "SearXNG Secret created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_searxng_secret.go
+++ b/internal/usecase/hermesagent_searxng_secret.go
@@ -20,8 +20,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 
 	existing, err := u.kube.GetSecret(ctx, GetSecretParam{NamespacedName: secretNsName})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get SearXNG Secret", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -32,8 +30,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 		err := u.kube.DeleteSecret(ctx, DeleteSecretParam{NamespacedName: secretNsName})
 		u.tel.IncSecretOperation(ctx, IncSecretOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to delete SearXNG Secret", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "SearXNG Secret deleted", "namespacedName", nsName)
@@ -48,15 +44,11 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 
 	secret, err := buildSearXNGSecret(ha)
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to build SearXNG Secret", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	err = u.kube.CreateSecretOwnedByHermesAgent(ctx, CreateSecretOfHermesAgentParam{HermesAgent: ha, Secret: secret})
 	u.tel.IncSecretOperation(ctx, IncSecretOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to create SearXNG Secret", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "SearXNG Secret created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_service.go
+++ b/internal/usecase/hermesagent_service.go
@@ -19,6 +19,8 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 
 	existing, err := u.kube.GetService(ctx, GetServiceParam{NamespacedName: nsName})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get Service", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -30,6 +32,8 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 		err := u.kube.UpdateServiceOwnedByHermesAgent(ctx, UpdateServiceParam{HermesAgent: ha, Service: desired})
 		u.tel.IncServiceOperation(ctx, IncServiceOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to update Service", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Service updated", "namespacedName", nsName)
@@ -40,6 +44,8 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 	err = u.kube.CreateServiceOwnedByHermesAgent(ctx, CreateServiceOfHermesAgentParam{HermesAgent: ha, Service: desired})
 	u.tel.IncServiceOperation(ctx, IncServiceOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to create Service", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "Service created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_service.go
+++ b/internal/usecase/hermesagent_service.go
@@ -19,8 +19,6 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 
 	existing, err := u.kube.GetService(ctx, GetServiceParam{NamespacedName: nsName})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get Service", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -32,8 +30,6 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 		err := u.kube.UpdateServiceOwnedByHermesAgent(ctx, UpdateServiceParam{HermesAgent: ha, Service: desired})
 		u.tel.IncServiceOperation(ctx, IncServiceOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to update Service", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Service updated", "namespacedName", nsName)
@@ -44,8 +40,6 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 	err = u.kube.CreateServiceOwnedByHermesAgent(ctx, CreateServiceOfHermesAgentParam{HermesAgent: ha, Service: desired})
 	u.tel.IncServiceOperation(ctx, IncServiceOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to create Service", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "Service created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_serviceaccount.go
+++ b/internal/usecase/hermesagent_serviceaccount.go
@@ -18,8 +18,6 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 
 	existing, err := u.kube.GetServiceAccount(ctx, GetServiceAccountParam{NamespacedName: nsName})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get ServiceAccount", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -30,8 +28,6 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 		err := u.kube.DeleteServiceAccount(ctx, DeleteServiceAccountParam{NamespacedName: nsName})
 		u.tel.IncServiceAccountOperation(ctx, IncServiceAccountOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to delete ServiceAccount", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "ServiceAccount deleted", "namespacedName", nsName)
@@ -44,8 +40,6 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 		err := u.kube.UpdateServiceAccountOwnedByHermesAgent(ctx, UpdateServiceAccountParam{HermesAgent: ha, ServiceAccount: desired})
 		u.tel.IncServiceAccountOperation(ctx, IncServiceAccountOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to update ServiceAccount", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "ServiceAccount updated", "namespacedName", nsName)
@@ -56,8 +50,6 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 	err = u.kube.CreateServiceAccountOwnedByHermesAgent(ctx, CreateServiceAccountOfHermesAgentParam{HermesAgent: ha, ServiceAccount: desired})
 	u.tel.IncServiceAccountOperation(ctx, IncServiceAccountOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to create ServiceAccount", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "ServiceAccount created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_serviceaccount.go
+++ b/internal/usecase/hermesagent_serviceaccount.go
@@ -18,6 +18,8 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 
 	existing, err := u.kube.GetServiceAccount(ctx, GetServiceAccountParam{NamespacedName: nsName})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get ServiceAccount", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -28,6 +30,8 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 		err := u.kube.DeleteServiceAccount(ctx, DeleteServiceAccountParam{NamespacedName: nsName})
 		u.tel.IncServiceAccountOperation(ctx, IncServiceAccountOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to delete ServiceAccount", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "ServiceAccount deleted", "namespacedName", nsName)
@@ -40,6 +44,8 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 		err := u.kube.UpdateServiceAccountOwnedByHermesAgent(ctx, UpdateServiceAccountParam{HermesAgent: ha, ServiceAccount: desired})
 		u.tel.IncServiceAccountOperation(ctx, IncServiceAccountOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to update ServiceAccount", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "ServiceAccount updated", "namespacedName", nsName)
@@ -50,6 +56,8 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 	err = u.kube.CreateServiceAccountOwnedByHermesAgent(ctx, CreateServiceAccountOfHermesAgentParam{HermesAgent: ha, ServiceAccount: desired})
 	u.tel.IncServiceAccountOperation(ctx, IncServiceAccountOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to create ServiceAccount", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	u.tel.Debug(ctx, "ServiceAccount created", "namespacedName", nsName)

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -31,8 +31,6 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 		NamespacedName: nsName,
 	})
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get StatefulSet", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -44,8 +42,6 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 		err := u.kube.UpdateStatefulSetOwnedByHermesAgent(ctx, UpdateStatefulSetParam{HermesAgent: ha, StatefulSet: desired})
 		u.tel.IncStatefulSetOperation(ctx, IncStatefulSetOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to update StatefulSet", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		stsOp = "updated"
@@ -53,8 +49,6 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 		err = u.kube.CreateStatefulSetOwnedByHermesAgent(ctx, CreateStatefulSetOfHermesAgentParam{HermesAgent: ha, StatefulSet: desired})
 		u.tel.IncStatefulSetOperation(ctx, IncStatefulSetOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to create StatefulSet", "namespacedName", nsName)
-			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		stsOp = "created"
@@ -63,8 +57,6 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 	ha.Status.ManagedResources.StatefulSet = ha.Name
 	ha.Status.Phase = u.derivePhase(ctx, ha)
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
-		u.tel.Error(ctx, err, "Failed to update HermesAgent status", "namespacedName", nsName)
-		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -31,6 +31,8 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 		NamespacedName: nsName,
 	})
 	if err != nil {
+		u.tel.Error(ctx, err, "Failed to get StatefulSet", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
@@ -42,6 +44,8 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 		err := u.kube.UpdateStatefulSetOwnedByHermesAgent(ctx, UpdateStatefulSetParam{HermesAgent: ha, StatefulSet: desired})
 		u.tel.IncStatefulSetOperation(ctx, IncStatefulSetOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to update StatefulSet", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		stsOp = "updated"
@@ -49,6 +53,8 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 		err = u.kube.CreateStatefulSetOwnedByHermesAgent(ctx, CreateStatefulSetOfHermesAgentParam{HermesAgent: ha, StatefulSet: desired})
 		u.tel.IncStatefulSetOperation(ctx, IncStatefulSetOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 		if err != nil {
+			u.tel.Error(ctx, err, "Failed to create StatefulSet", "namespacedName", nsName)
+			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		stsOp = "created"
@@ -57,6 +63,8 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 	ha.Status.ManagedResources.StatefulSet = ha.Name
 	ha.Status.Phase = u.derivePhase(ctx, ha)
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+		u.tel.Error(ctx, err, "Failed to update HermesAgent status", "namespacedName", nsName)
+		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 


### PR DESCRIPTION
## Summary

- Removed `u.tel.Error` and `u.tel.IncReconcile(ResultError)` calls from all 10 sub-reconcile methods (`reconcileHermesConfigMap`, `reconcileHermesSecret`, `reconcileSearXNGConfigMap`, `reconcileSearXNGSecret`, `reconcileServiceAccount`, `reconcileRole`, `reconcileService`, `reconcileIngress`, `reconcileNetworkPolicy`, `reconcileStatefulSet`)
- Centralized both calls in the top-level `Reconcile` method, immediately after each sub-call returns an error
- Each error site now logs a resource-specific message (e.g. `"Failed to reconcile Hermes ConfigMap"`) so failures are identifiable at a glance without tracing the error chain
- Resource-operation metrics (`IncConfigMapOperation`, `IncStatefulSetOperation`, etc.) are unchanged — they remain in the sub-files where they belong

## Why

Error logging and the reconcile error counter were previously scattered across every sub-reconcile method at varying call depths. This made it hard to see all error observability in one place and ensured the log level/metric always matched the overall reconcile outcome. Lifting them to `Reconcile` puts error handling at the same level as the success and not-found paths that already live there.

## Reviewer notes

- The `!result.IsZero() && err == nil` path (StatefulSet pending requeue) is unaffected — the new `if err != nil` guard means no spurious error logs or metric increments for intentional non-zero results
- Sub-files only return bare `err`; no error wrapping was added
- `go build ./...` and `go test ./internal/usecase/...` pass cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)