### PR TITLE
fix: set HOME to /opt/data and propagate env/envFrom to init containers

### DIFF
--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -218,7 +218,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		}, ha.GetHermes().GetPorts()...),
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
-			{Name: "HOME", Value: hermesHomeMount + "/home"},
+			{Name: "HOME", Value: hermesHomeMount},
 			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:   ha.GetHermes().GetEnvFrom(),
@@ -321,6 +321,12 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{"/bin/sh", "-ec"},
 			Args:            []string{"chown -R 10000:10000 /opt/data"},
+			Env: append([]corev1.EnvVar{
+				{Name: "HERMES_HOME", Value: hermesHomeMount},
+				{Name: "HOME", Value: hermesHomeMount},
+				{Name: "PATH", Value: hermesPathEnv},
+			}, ha.GetHermes().GetEnv()...),
+			EnvFrom: ha.GetHermes().GetEnvFrom(),
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: hermesHomeVolume, MountPath: hermesHomeMount},
 			},
@@ -335,10 +341,12 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 			ImagePullPolicy: corev1.PullIfNotPresent,
 			Command:         []string{"/bin/sh", "-ec"},
 			Args:            []string{buildConfigScript()},
-			Env: []corev1.EnvVar{
+			Env: append([]corev1.EnvVar{
 				{Name: "HERMES_HOME", Value: hermesHomeMount},
+				{Name: "HOME", Value: hermesHomeMount},
 				{Name: "PATH", Value: hermesPathEnv},
-			},
+			}, ha.GetHermes().GetEnv()...),
+			EnvFrom:         ha.GetHermes().GetEnvFrom(),
 			SecurityContext: buildInitContainerSecurityContext(),
 			VolumeMounts: []corev1.VolumeMount{
 				{Name: hermesHomeVolume, MountPath: hermesHomeMount},
@@ -356,10 +364,12 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-ec"},
 		Args:            []string{buildWorkspaceScript()},
-		Env: []corev1.EnvVar{
+		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount},
 			{Name: "PATH", Value: hermesPathEnv},
-		},
+		}, ha.GetHermes().GetEnv()...),
+		EnvFrom:         ha.GetHermes().GetEnvFrom(),
 		SecurityContext: buildInitContainerSecurityContext(),
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: hermesHomeVolume, MountPath: hermesHomeMount},
@@ -376,10 +386,12 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-ec"},
 		Args:            []string{buildPluginsScript(plugins)},
-		Env: []corev1.EnvVar{
+		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount},
 			{Name: "PATH", Value: hermesPathEnv},
-		},
+		}, ha.GetHermes().GetEnv()...),
+		EnvFrom:         ha.GetHermes().GetEnvFrom(),
 		SecurityContext: buildInitContainerSecurityContext(),
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: hermesHomeVolume, MountPath: hermesHomeMount},
@@ -395,10 +407,12 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-ec"},
 		Args:            []string{buildSkillsScript(skills)},
-		Env: []corev1.EnvVar{
+		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount},
 			{Name: "PATH", Value: hermesPathEnv},
-		},
+		}, ha.GetHermes().GetEnv()...),
+		EnvFrom:         ha.GetHermes().GetEnvFrom(),
 		SecurityContext: buildInitContainerSecurityContext(),
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: hermesHomeVolume, MountPath: hermesHomeMount},
@@ -414,10 +428,12 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-ec"},
 		Args:            []string{buildBundlesScript(bundles)},
-		Env: []corev1.EnvVar{
+		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount},
 			{Name: "PATH", Value: hermesPathEnv},
-		},
+		}, ha.GetHermes().GetEnv()...),
+		EnvFrom:         ha.GetHermes().GetEnvFrom(),
 		SecurityContext: buildInitContainerSecurityContext(),
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: hermesHomeVolume, MountPath: hermesHomeMount},
@@ -433,10 +449,12 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-ec"},
 		Args:            []string{buildCronsScript(crons)},
-		Env: []corev1.EnvVar{
+		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount},
 			{Name: "PATH", Value: hermesPathEnv},
-		},
+		}, ha.GetHermes().GetEnv()...),
+		EnvFrom:         ha.GetHermes().GetEnvFrom(),
 		SecurityContext: buildInitContainerSecurityContext(),
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: hermesHomeVolume, MountPath: hermesHomeMount},


### PR DESCRIPTION
## Summary

- Change the `HOME` env var injected into the hermes-agent container from `/opt/data/home` to `/opt/data`, aligning it with `HERMES_HOME`.
- Inject `env` (user-defined vars from `ha.GetHermes().GetEnv()`) and `envFrom` (`ha.GetHermes().GetEnvFrom()`) into all 7 hermes init containers (`init-chown-data`, `init-config`, `init-workspace`, `init-plugins`, `init-skills`, `init-bundles`, `init-crons`), mirroring what the main hermes-agent container already received.
- Also add `HOME` to each init container's fixed env vars for consistency.

## Why

Init containers run the hermes CLI to install plugins, skills, bundles, crons, etc. Those operations need the same credentials and config (API keys, tokens) that the main container uses. Without `env`/`envFrom` propagation, any secret or ConfigMap reference set on the `HermesAgent` spec was invisible to init containers, causing failures at startup.

## Reviewer notes

The `init-searxng-config` container is intentionally excluded — it belongs to the SearXNG sidecar and has no need for hermes-agent env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)