### PR TITLE
refactor: remove per-resource operation metrics from Telemetry

### DIFF
--- a/internal/infras/prometheus.go
+++ b/internal/infras/prometheus.go
@@ -15,15 +15,6 @@ const telemetryLoggerName = "hermesagent"
 type PrometheusTelemetry struct {
 	reconcileTotal    *prometheus.CounterVec
 	reconcileDuration *prometheus.HistogramVec
-	configMapOps      *prometheus.CounterVec
-	secretOps         *prometheus.CounterVec
-	statefulSetOps    *prometheus.CounterVec
-	serviceAccountOps *prometheus.CounterVec
-	roleOps           *prometheus.CounterVec
-	roleBindingOps    *prometheus.CounterVec
-	serviceOps        *prometheus.CounterVec
-	ingressOps        *prometheus.CounterVec
-	networkPolicyOps  *prometheus.CounterVec
 	notFoundTotal     *prometheus.CounterVec
 }
 
@@ -38,42 +29,6 @@ func NewPrometheusTelemetry() *PrometheusTelemetry {
 			Help:    "Duration of HermesAgent reconciliations in seconds.",
 			Buckets: prometheus.DefBuckets,
 		}, []string{"namespace", "name"}),
-		configMapOps: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "hermesagent_configmap_operations_total",
-			Help: "Total number of ConfigMap create/update operations.",
-		}, []string{"namespace", "name", "operation", "result"}),
-		secretOps: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "hermesagent_secret_operations_total",
-			Help: "Total number of Secret create/delete operations.",
-		}, []string{"namespace", "name", "operation", "result"}),
-		statefulSetOps: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "hermesagent_statefulset_operations_total",
-			Help: "Total number of StatefulSet create/update operations.",
-		}, []string{"namespace", "name", "operation", "result"}),
-		serviceAccountOps: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "hermesagent_serviceaccount_operations_total",
-			Help: "Total number of ServiceAccount create/update/delete operations.",
-		}, []string{"namespace", "name", "operation", "result"}),
-		roleOps: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "hermesagent_role_operations_total",
-			Help: "Total number of Role create/update/delete operations.",
-		}, []string{"namespace", "name", "operation", "result"}),
-		roleBindingOps: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "hermesagent_rolebinding_operations_total",
-			Help: "Total number of RoleBinding create/update/delete operations.",
-		}, []string{"namespace", "name", "operation", "result"}),
-		serviceOps: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "hermesagent_service_operations_total",
-			Help: "Total number of Service create/update operations.",
-		}, []string{"namespace", "name", "operation", "result"}),
-		ingressOps: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "hermesagent_ingress_operations_total",
-			Help: "Total number of Ingress create/update/delete operations.",
-		}, []string{"namespace", "name", "operation", "result"}),
-		networkPolicyOps: prometheus.NewCounterVec(prometheus.CounterOpts{
-			Name: "hermesagent_networkpolicy_operations_total",
-			Help: "Total number of NetworkPolicy create/update/delete operations.",
-		}, []string{"namespace", "name", "operation", "result"}),
 		notFoundTotal: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "hermesagent_not_found_total",
 			Help: "Total number of reconciliations where the HermesAgent was not found.",
@@ -83,15 +38,6 @@ func NewPrometheusTelemetry() *PrometheusTelemetry {
 	metrics.Registry.MustRegister(
 		m.reconcileTotal,
 		m.reconcileDuration,
-		m.configMapOps,
-		m.secretOps,
-		m.statefulSetOps,
-		m.serviceAccountOps,
-		m.roleOps,
-		m.roleBindingOps,
-		m.serviceOps,
-		m.ingressOps,
-		m.networkPolicyOps,
 		m.notFoundTotal,
 	)
 
@@ -120,42 +66,6 @@ func (m *PrometheusTelemetry) IncReconcile(_ context.Context, param usecase.IncR
 
 func (m *PrometheusTelemetry) ObserveReconcileDuration(_ context.Context, param usecase.ObserveReconcileDurationParam) {
 	m.reconcileDuration.WithLabelValues(param.NamespacedName.Namespace, param.NamespacedName.Name).Observe(param.Seconds)
-}
-
-func (m *PrometheusTelemetry) IncConfigMapOperation(_ context.Context, param usecase.IncConfigMapOperationParam) {
-	m.configMapOps.WithLabelValues(param.NamespacedName.Namespace, param.NamespacedName.Name, param.Operation.String(), param.Result.String()).Inc()
-}
-
-func (m *PrometheusTelemetry) IncSecretOperation(_ context.Context, param usecase.IncSecretOperationParam) {
-	m.secretOps.WithLabelValues(param.NamespacedName.Namespace, param.NamespacedName.Name, param.Operation.String(), param.Result.String()).Inc()
-}
-
-func (m *PrometheusTelemetry) IncStatefulSetOperation(_ context.Context, param usecase.IncStatefulSetOperationParam) {
-	m.statefulSetOps.WithLabelValues(param.NamespacedName.Namespace, param.NamespacedName.Name, param.Operation.String(), param.Result.String()).Inc()
-}
-
-func (m *PrometheusTelemetry) IncServiceAccountOperation(_ context.Context, param usecase.IncServiceAccountOperationParam) {
-	m.serviceAccountOps.WithLabelValues(param.NamespacedName.Namespace, param.NamespacedName.Name, param.Operation.String(), param.Result.String()).Inc()
-}
-
-func (m *PrometheusTelemetry) IncRoleOperation(_ context.Context, param usecase.IncRoleOperationParam) {
-	m.roleOps.WithLabelValues(param.NamespacedName.Namespace, param.NamespacedName.Name, param.Operation.String(), param.Result.String()).Inc()
-}
-
-func (m *PrometheusTelemetry) IncRoleBindingOperation(_ context.Context, param usecase.IncRoleBindingOperationParam) {
-	m.roleBindingOps.WithLabelValues(param.NamespacedName.Namespace, param.NamespacedName.Name, param.Operation.String(), param.Result.String()).Inc()
-}
-
-func (m *PrometheusTelemetry) IncServiceOperation(_ context.Context, param usecase.IncServiceOperationParam) {
-	m.serviceOps.WithLabelValues(param.NamespacedName.Namespace, param.NamespacedName.Name, param.Operation.String(), param.Result.String()).Inc()
-}
-
-func (m *PrometheusTelemetry) IncIngressOperation(_ context.Context, param usecase.IncIngressOperationParam) {
-	m.ingressOps.WithLabelValues(param.NamespacedName.Namespace, param.NamespacedName.Name, param.Operation.String(), param.Result.String()).Inc()
-}
-
-func (m *PrometheusTelemetry) IncNetworkPolicyOperation(_ context.Context, param usecase.IncNetworkPolicyOperationParam) {
-	m.networkPolicyOps.WithLabelValues(param.NamespacedName.Namespace, param.NamespacedName.Name, param.Operation.String(), param.Result.String()).Inc()
 }
 
 func (m *PrometheusTelemetry) IncNotFound(_ context.Context, param usecase.IncNotFoundParam) {

--- a/internal/usecase/hermesagent.go
+++ b/internal/usecase/hermesagent.go
@@ -128,10 +128,3 @@ func (u *HermesAgentUseCase) Reconcile(ctx context.Context, param ReconcileParam
 	u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultSuccess})
 	return ctrl.Result{}, nil
 }
-
-func resultOf(err error) Result {
-	if err != nil {
-		return ResultError
-	}
-	return ResultSuccess
-}

--- a/internal/usecase/hermesagent_hermes_configmap.go
+++ b/internal/usecase/hermesagent_hermes_configmap.go
@@ -34,7 +34,6 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 	if cm != nil {
 		desired.ResourceVersion = cm.ResourceVersion
 		err := u.kube.UpdateConfigMapOwnedByHermesAgent(ctx, UpdateConfigMapParam{HermesAgent: ha, ConfigMap: desired})
-		u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
@@ -44,7 +43,6 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 	}
 
 	err = u.kube.CreateConfigMapOwnedByHermesAgent(ctx, CreateConfigMapOfHermesAgentParam{HermesAgent: ha, ConfigMap: desired})
-	u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}

--- a/internal/usecase/hermesagent_hermes_secret.go
+++ b/internal/usecase/hermesagent_hermes_secret.go
@@ -50,7 +50,6 @@ func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agen
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	err = u.kube.CreateSecretOwnedByHermesAgent(ctx, CreateSecretOfHermesAgentParam{HermesAgent: ha, Secret: secret})
-	u.tel.IncSecretOperation(ctx, IncSecretOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}

--- a/internal/usecase/hermesagent_ingress.go
+++ b/internal/usecase/hermesagent_ingress.go
@@ -25,7 +25,6 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 	if !ing.IsEnabled() {
 		if existing != nil {
 			err := u.kube.DeleteIngress(ctx, DeleteIngressParam{NamespacedName: nsName})
-			u.tel.IncIngressOperation(ctx, IncIngressOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
@@ -42,7 +41,6 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 	if existing != nil {
 		desired.ResourceVersion = existing.ResourceVersion
 		err := u.kube.UpdateIngressOwnedByHermesAgent(ctx, UpdateIngressParam{HermesAgent: ha, Ingress: desired})
-		u.tel.IncIngressOperation(ctx, IncIngressOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
@@ -52,7 +50,6 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 	}
 
 	err = u.kube.CreateIngressOwnedByHermesAgent(ctx, CreateIngressOfHermesAgentParam{HermesAgent: ha, Ingress: desired})
-	u.tel.IncIngressOperation(ctx, IncIngressOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}

--- a/internal/usecase/hermesagent_networkpolicy.go
+++ b/internal/usecase/hermesagent_networkpolicy.go
@@ -28,7 +28,6 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 	if !np.IsEnabled() {
 		if existing != nil {
 			err := u.kube.DeleteNetworkPolicy(ctx, DeleteNetworkPolicyParam{NamespacedName: nsName})
-			u.tel.IncNetworkPolicyOperation(ctx, IncNetworkPolicyOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
@@ -45,7 +44,6 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 	if existing != nil {
 		desired.ResourceVersion = existing.ResourceVersion
 		err := u.kube.UpdateNetworkPolicyOwnedByHermesAgent(ctx, UpdateNetworkPolicyParam{HermesAgent: ha, NetworkPolicy: desired})
-		u.tel.IncNetworkPolicyOperation(ctx, IncNetworkPolicyOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
@@ -55,7 +53,6 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 	}
 
 	err = u.kube.CreateNetworkPolicyOwnedByHermesAgent(ctx, CreateNetworkPolicyOfHermesAgentParam{HermesAgent: ha, NetworkPolicy: desired})
-	u.tel.IncNetworkPolicyOperation(ctx, IncNetworkPolicyOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}

--- a/internal/usecase/hermesagent_role.go
+++ b/internal/usecase/hermesagent_role.go
@@ -30,7 +30,6 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 	if len(rules) == 0 || saName == "" {
 		if existingRB != nil {
 			err := u.kube.DeleteRoleBinding(ctx, DeleteRoleBindingParam{NamespacedName: nsName})
-			u.tel.IncRoleBindingOperation(ctx, IncRoleBindingOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
@@ -38,7 +37,6 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		}
 		if existingRole != nil {
 			err := u.kube.DeleteRole(ctx, DeleteRoleParam{NamespacedName: nsName})
-			u.tel.IncRoleOperation(ctx, IncRoleOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
@@ -56,14 +54,12 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 	if existingRole != nil {
 		desiredRole.ResourceVersion = existingRole.ResourceVersion
 		err := u.kube.UpdateRoleOwnedByHermesAgent(ctx, UpdateRoleParam{HermesAgent: ha, Role: desiredRole})
-		u.tel.IncRoleOperation(ctx, IncRoleOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Role updated", "namespacedName", nsName)
 	} else {
 		err := u.kube.CreateRoleOwnedByHermesAgent(ctx, CreateRoleOfHermesAgentParam{HermesAgent: ha, Role: desiredRole})
-		u.tel.IncRoleOperation(ctx, IncRoleOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
@@ -74,14 +70,12 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 	if existingRB != nil {
 		desiredRB.ResourceVersion = existingRB.ResourceVersion
 		err := u.kube.UpdateRoleBindingOwnedByHermesAgent(ctx, UpdateRoleBindingParam{HermesAgent: ha, RoleBinding: desiredRB})
-		u.tel.IncRoleBindingOperation(ctx, IncRoleBindingOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "RoleBinding updated", "namespacedName", nsName)
 	} else {
 		err := u.kube.CreateRoleBindingOwnedByHermesAgent(ctx, CreateRoleBindingOfHermesAgentParam{HermesAgent: ha, RoleBinding: desiredRB})
-		u.tel.IncRoleBindingOperation(ctx, IncRoleBindingOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}

--- a/internal/usecase/hermesagent_searxng_configmap.go
+++ b/internal/usecase/hermesagent_searxng_configmap.go
@@ -24,7 +24,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 	if !ha.GetSearXNG().IsEnabled() {
 		if existing != nil {
 			err := u.kube.DeleteConfigMap(ctx, DeleteConfigMapParam{NamespacedName: cmNsName})
-			u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
@@ -41,7 +40,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 	if existing != nil {
 		desired.ResourceVersion = existing.ResourceVersion
 		err := u.kube.UpdateConfigMapOwnedByHermesAgent(ctx, UpdateConfigMapParam{HermesAgent: ha, ConfigMap: desired})
-		u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
@@ -51,7 +49,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 	}
 
 	err = u.kube.CreateConfigMapOwnedByHermesAgent(ctx, CreateConfigMapOfHermesAgentParam{HermesAgent: ha, ConfigMap: desired})
-	u.tel.IncConfigMapOperation(ctx, IncConfigMapOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}

--- a/internal/usecase/hermesagent_searxng_secret.go
+++ b/internal/usecase/hermesagent_searxng_secret.go
@@ -26,7 +26,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 	if !ha.GetSearXNG().IsEnabled() {
 		if existing != nil {
 			err := u.kube.DeleteSecret(ctx, DeleteSecretParam{NamespacedName: secretNsName})
-			u.tel.IncSecretOperation(ctx, IncSecretOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
@@ -50,7 +49,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	err = u.kube.CreateSecretOwnedByHermesAgent(ctx, CreateSecretOfHermesAgentParam{HermesAgent: ha, Secret: secret})
-	u.tel.IncSecretOperation(ctx, IncSecretOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}

--- a/internal/usecase/hermesagent_service.go
+++ b/internal/usecase/hermesagent_service.go
@@ -28,7 +28,6 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 		// ClusterIP is immutable; carry it over from the existing Service.
 		desired.Spec.ClusterIP = existing.Spec.ClusterIP
 		err := u.kube.UpdateServiceOwnedByHermesAgent(ctx, UpdateServiceParam{HermesAgent: ha, Service: desired})
-		u.tel.IncServiceOperation(ctx, IncServiceOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
@@ -38,7 +37,6 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 	}
 
 	err = u.kube.CreateServiceOwnedByHermesAgent(ctx, CreateServiceOfHermesAgentParam{HermesAgent: ha, Service: desired})
-	u.tel.IncServiceOperation(ctx, IncServiceOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}

--- a/internal/usecase/hermesagent_serviceaccount.go
+++ b/internal/usecase/hermesagent_serviceaccount.go
@@ -24,7 +24,6 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 	if !ha.GetSecurity().GetRBAC().ShouldCreateServiceAccount() {
 		if existing != nil {
 			err := u.kube.DeleteServiceAccount(ctx, DeleteServiceAccountParam{NamespacedName: nsName})
-			u.tel.IncServiceAccountOperation(ctx, IncServiceAccountOperationParam{NamespacedName: nsName, Operation: OperationDelete, Result: resultOf(err)})
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
@@ -41,7 +40,6 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 	if existing != nil {
 		desired.ResourceVersion = existing.ResourceVersion
 		err := u.kube.UpdateServiceAccountOwnedByHermesAgent(ctx, UpdateServiceAccountParam{HermesAgent: ha, ServiceAccount: desired})
-		u.tel.IncServiceAccountOperation(ctx, IncServiceAccountOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
@@ -51,7 +49,6 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 	}
 
 	err = u.kube.CreateServiceAccountOwnedByHermesAgent(ctx, CreateServiceAccountOfHermesAgentParam{HermesAgent: ha, ServiceAccount: desired})
-	u.tel.IncServiceAccountOperation(ctx, IncServiceAccountOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -40,14 +40,12 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 	if sts != nil {
 		desired.ResourceVersion = sts.ResourceVersion
 		err := u.kube.UpdateStatefulSetOwnedByHermesAgent(ctx, UpdateStatefulSetParam{HermesAgent: ha, StatefulSet: desired})
-		u.tel.IncStatefulSetOperation(ctx, IncStatefulSetOperationParam{NamespacedName: nsName, Operation: OperationUpdate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		stsOp = "updated"
 	} else {
 		err = u.kube.CreateStatefulSetOwnedByHermesAgent(ctx, CreateStatefulSetOfHermesAgentParam{HermesAgent: ha, StatefulSet: desired})
-		u.tel.IncStatefulSetOperation(ctx, IncStatefulSetOperationParam{NamespacedName: nsName, Operation: OperationCreate, Result: resultOf(err)})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}

--- a/internal/usecase/interface.go
+++ b/internal/usecase/interface.go
@@ -22,17 +22,6 @@ const (
 
 func (r Result) String() string { return string(r) }
 
-// Operation is the kind of write performed on a child resource, used as a metric label.
-type Operation string
-
-const (
-	OperationCreate Operation = "create"
-	OperationUpdate Operation = "update"
-	OperationDelete Operation = "delete"
-)
-
-func (o Operation) String() string { return string(o) }
-
 // Telemetry collects logs and metrics emitted by the usecase. Each metric has
 // its own specific method; the implementation owns the underlying collector names.
 type Telemetry interface {
@@ -44,15 +33,6 @@ type Telemetry interface {
 	// Metrics
 	IncReconcile(ctx context.Context, param IncReconcileParam)
 	ObserveReconcileDuration(ctx context.Context, param ObserveReconcileDurationParam)
-	IncConfigMapOperation(ctx context.Context, param IncConfigMapOperationParam)
-	IncSecretOperation(ctx context.Context, param IncSecretOperationParam)
-	IncStatefulSetOperation(ctx context.Context, param IncStatefulSetOperationParam)
-	IncServiceAccountOperation(ctx context.Context, param IncServiceAccountOperationParam)
-	IncRoleOperation(ctx context.Context, param IncRoleOperationParam)
-	IncRoleBindingOperation(ctx context.Context, param IncRoleBindingOperationParam)
-	IncServiceOperation(ctx context.Context, param IncServiceOperationParam)
-	IncIngressOperation(ctx context.Context, param IncIngressOperationParam)
-	IncNetworkPolicyOperation(ctx context.Context, param IncNetworkPolicyOperationParam)
 	IncNotFound(ctx context.Context, param IncNotFoundParam)
 }
 
@@ -64,60 +44,6 @@ type IncReconcileParam struct {
 type ObserveReconcileDurationParam struct {
 	NamespacedName types.NamespacedName
 	Seconds        float64
-}
-
-type IncConfigMapOperationParam struct {
-	NamespacedName types.NamespacedName
-	Operation      Operation
-	Result         Result
-}
-
-type IncSecretOperationParam struct {
-	NamespacedName types.NamespacedName
-	Operation      Operation
-	Result         Result
-}
-
-type IncStatefulSetOperationParam struct {
-	NamespacedName types.NamespacedName
-	Operation      Operation
-	Result         Result
-}
-
-type IncServiceAccountOperationParam struct {
-	NamespacedName types.NamespacedName
-	Operation      Operation
-	Result         Result
-}
-
-type IncRoleOperationParam struct {
-	NamespacedName types.NamespacedName
-	Operation      Operation
-	Result         Result
-}
-
-type IncRoleBindingOperationParam struct {
-	NamespacedName types.NamespacedName
-	Operation      Operation
-	Result         Result
-}
-
-type IncServiceOperationParam struct {
-	NamespacedName types.NamespacedName
-	Operation      Operation
-	Result         Result
-}
-
-type IncIngressOperationParam struct {
-	NamespacedName types.NamespacedName
-	Operation      Operation
-	Result         Result
-}
-
-type IncNetworkPolicyOperationParam struct {
-	NamespacedName types.NamespacedName
-	Operation      Operation
-	Result         Result
 }
 
 type IncNotFoundParam struct {


### PR DESCRIPTION
## Summary

- Removes 9 `Inc*Operation` methods (`IncConfigMapOperation`, `IncSecretOperation`, `IncStatefulSetOperation`, `IncServiceAccountOperation`, `IncRoleOperation`, `IncRoleBindingOperation`, `IncServiceOperation`, `IncIngressOperation`, `IncNetworkPolicyOperation`) from the `Telemetry` interface and their Prometheus implementation
- Removes the associated 9 param struct types and the `Operation` type/constants (`OperationCreate`, `OperationUpdate`, `OperationDelete`) from `internal/usecase/interface.go`
- Removes all 27 call sites across 9 usecase reconcile files
- Removes the now-dead `resultOf` helper from `hermesagent.go`
- Removes the 9 backing `*prometheus.CounterVec` fields and their registrations from `NewPrometheusTelemetry`

## Why

These per-resource operation counters are not necessary. The high-level `IncReconcile` and `ObserveReconcileDuration` metrics on the `Telemetry` interface are sufficient for observing reconciler health.

## Reviewer notes

- `Result`, `ResultSuccess`, `ResultError`, `ResultNotFound` are retained — they are still used by `IncReconcileParam`
- No behaviour changes; this is a pure deletion of unused instrumentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)