### PR TITLE
perf: use native build platform in Dockerfile to avoid QEMU emulation for arm64

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.25 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.25 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
## Summary

- Add `--platform=$BUILDPLATFORM` to the `builder` stage in `Dockerfile`
- This forces the Go compilation to run natively on the host (`linux/amd64`) instead of under QEMU emulation when targeting `arm64`
- `TARGETOS` / `TARGETARCH` are already declared and passed to `go build`, so Go's cross-compilation handles producing the correct binary for each target platform

## Why

QEMU-based emulation of `arm64` is 10–20x slower than native execution. The builder stage was running emulated for `arm64` builds despite the Go toolchain supporting cross-compilation out of the box. Pinning the builder to `$BUILDPLATFORM` eliminates the emulation entirely — only the trivial final layer (copying the binary into distroless) is assembled per-platform.

No workflow changes are required; BuildKit automatically injects `BUILDPLATFORM`, `TARGETOS`, and `TARGETARCH` for each platform pass.

## Reviewer notes

The only change is a single token on line 2 of `Dockerfile`. No logic changes.