### PR TITLE
ci: publish Helm chart with pinned appVersion after Docker image push

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -37,3 +37,20 @@ jobs:
           tags: |
             ghcr.io/hermeum/hermes-agent-operator:${{ github.ref_name }}
             ghcr.io/hermeum/hermes-agent-operator:latest
+
+      - name: Install Helm
+        run: make install-helm
+
+      - name: Log in to GHCR OCI registry
+        run: |
+          echo "${{ secrets.GHCR_TOKEN }}" | helm registry login ghcr.io \
+            --username ${{ github.actor }} \
+            --password-stdin
+
+      - name: Package and publish Helm chart pinned to app version
+        run: |
+          VERSION=${{ github.ref_name }}
+          APP_VERSION=${VERSION#v}
+          make helm-push \
+            HELM_CHART_VERSION=${APP_VERSION} \
+            HELM_EXTRA_ARGS="--app-version ${APP_VERSION}"


### PR DESCRIPTION
## Summary

- Extends `docker-publish.yml` to package and push the Helm chart immediately after the Docker image is published
- Passes `HELM_CHART_VERSION` and `HELM_EXTRA_ARGS=--app-version` as Make variables so both the chart `version` and `appVersion` are pinned to the exact ref being released — no `Chart.yaml` edits required
- Uses the same Helm login / `make helm-push` pattern already established in `helm-publish.yml`

## Why

Previously, Docker image publishing and Helm chart publishing were separate manual workflows. This meant the Helm chart's `appVersion` could lag behind or mismatch the published image tag. Combining them into one workflow guarantees the chart always references the exact image that was just pushed.

## Test plan

- [ ] Trigger the workflow manually from a versioned ref (e.g. `v0.2.0`)
- [ ] Confirm Docker image `ghcr.io/hermeum/hermes-agent-operator:v0.2.0` and `:latest` are pushed
- [ ] Confirm `hermes-agent-operator-0.2.0.tgz` appears in `oci://ghcr.io/hermeum`
- [ ] Pull the chart and verify `appVersion: "0.2.0"` and `version: 0.2.0` inside

🤖 Generated with [Claude Code](https://claude.com/claude-code)