### PR TITLE
feat: generate helm chart

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,7 @@ After changing API types (`api/v1alpha1/`), regenerate the DeepCopy methods and 
 ```sh
 make generate   # regenerate zz_generated.deepcopy.go
 make manifests  # regenerate CRDs and RBAC from markers
+kubebuilder edit --plugins=helm/v2-alpha
 ```
 
 ## Lint
@@ -40,23 +41,3 @@ make install
 make run
 ```
 
-## Build and push image
-
-```sh
-make docker-build IMG=<registry>/hermes-agent-operator:<tag>
-make docker-push  IMG=<registry>/hermes-agent-operator:<tag>
-```
-
-## Deploy to a cluster
-
-```sh
-make install                          # install CRDs
-make deploy IMG=<registry>/hermes-agent-operator:<tag>   # deploy the manager
-```
-
-To remove:
-
-```sh
-make undeploy
-make uninstall
-```

--- a/config/crd/bases/agents.hermeum.app_hermesagents.yaml
+++ b/config/crd/bases/agents.hermeum.app_hermesagents.yaml
@@ -2335,14 +2335,14 @@ spec:
                           enabled:
                             description: |-
                               enabled turns on the gateway API server (sets API_SERVER_ENABLED=true).
-                              The operator generates an API key Secret automatically unless existingSecret is set.
+                              The operator always generates an API key Secret automatically.
                             type: boolean
                           existingSecret:
                             description: |-
-                              existingSecret references a user-managed Secret that contains the API key,
-                              instead of using the operator-generated one. The referenced Secret must
-                              exist in the same namespace as the HermesAgent. When set, the operator
-                              skips generating its own Secret.
+                              existingSecret references a user-managed Secret that contains the API key.
+                              When set, its key is injected into the container instead of the operator-generated one.
+                              The referenced Secret must exist in the same namespace as the HermesAgent.
+                              The operator still generates its own Secret regardless of this field.
                             properties:
                               key:
                                 description: The key of the secret to select from.  Must

--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -3,7 +3,7 @@ name: hermes-agent-operator
 description: A Helm chart to distribute hermes-agent-operator
 type: application
 
-version: 0.1.2
+version: 0.2.0
 appVersion: "0.2.0"
 
 keywords:

--- a/dist/chart/templates/crd/hermesagents.agents.hermeum.app.yaml
+++ b/dist/chart/templates/crd/hermesagents.agents.hermeum.app.yaml
@@ -2329,18 +2329,87 @@ spec:
                     description: config holds the Hermes agent config.yml configuration.
                     properties:
                       apiServer:
-                        description: apiServer configures the gateway API server.
+                        description: |-
+                          apiServer configures the gateway API server. For convenience, the operator
+                          automatically generates an API key Secret internally — no manual secret
+                          management required. Set existingSecret to supply your own Secret instead.
+                          The Secret is persisted across reconciles; enabling the server injects it into the container.
                         properties:
                           enabled:
                             description: |-
                               enabled turns on the gateway API server (sets API_SERVER_ENABLED=true).
-                              The API key secret is always created regardless of this field.
+                              The operator always generates an API key Secret automatically.
                             type: boolean
+                          existingSecret:
+                            description: |-
+                              existingSecret references a user-managed Secret that contains the API key.
+                              When set, its key is injected into the container instead of the operator-generated one.
+                              The referenced Secret must exist in the same namespace as the HermesAgent.
+                              The operator still generates its own Secret regardless of this field.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       raw:
                         description: raw holds the verbatim Hermes agent config.yml
                           as free-form YAML/JSON.
                         x-kubernetes-preserve-unknown-fields: true
+                      webhook:
+                        description: webhook configures the webhook ingress.
+                        properties:
+                          enabled:
+                            description: |-
+                              enabled activates the webhook listener (sets WEBHOOK_ENABLED=true).
+                              When enabled without secretRef, WEBHOOK_SECRET is injected from the
+                              operator-managed hermes Secret.
+                            type: boolean
+                          secretRef:
+                            description: |-
+                              secretRef references an existing Secret key to use as the HMAC secret
+                              instead of the operator-generated one. Use this to share a known value
+                              with external webhook senders, or to set "INSECURE_NO_AUTH" for testing.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
                     type: object
                   crons:
                     description: crons is a list of scheduled jobs to manage via hermes
@@ -6730,6 +6799,46 @@ spec:
                 x-kubernetes-list-map-keys:
                 - type
                 x-kubernetes-list-type: map
+              managedResources:
+                description: managedResources describes the Kubernetes resources currently
+                  owned by this HermesAgent.
+                properties:
+                  hermesConfigMap:
+                    description: hermesConfigMap is the name of the Hermes configuration
+                      ConfigMap.
+                    type: string
+                  hermesSecret:
+                    description: hermesSecret is the name of the Hermes API key Secret.
+                    type: string
+                  ingress:
+                    description: ingress is the name of the managed Ingress.
+                    type: string
+                  networkPolicy:
+                    description: networkPolicy is the name of the managed NetworkPolicy.
+                    type: string
+                  role:
+                    description: role is the name of the managed Role.
+                    type: string
+                  roleBinding:
+                    description: roleBinding is the name of the managed RoleBinding.
+                    type: string
+                  searxngConfigMap:
+                    description: searxngConfigMap is the name of the SearXNG configuration
+                      ConfigMap.
+                    type: string
+                  searxngSecret:
+                    description: searxngSecret is the name of the SearXNG Secret.
+                    type: string
+                  service:
+                    description: service is the name of the managed Service.
+                    type: string
+                  serviceAccount:
+                    description: serviceAccount is the name of the managed ServiceAccount.
+                    type: string
+                  statefulSet:
+                    description: statefulSet is the name of the managed StatefulSet.
+                    type: string
+                type: object
               phase:
                 description: |-
                   phase is the current lifecycle phase of the HermesAgent, mirroring the underlying pod phase.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2334,18 +2334,87 @@ spec:
                     description: config holds the Hermes agent config.yml configuration.
                     properties:
                       apiServer:
-                        description: apiServer configures the gateway API server.
+                        description: |-
+                          apiServer configures the gateway API server. For convenience, the operator
+                          automatically generates an API key Secret internally — no manual secret
+                          management required. Set existingSecret to supply your own Secret instead.
+                          The Secret is persisted across reconciles; enabling the server injects it into the container.
                         properties:
                           enabled:
                             description: |-
                               enabled turns on the gateway API server (sets API_SERVER_ENABLED=true).
-                              The API key secret is always created regardless of this field.
+                              The operator always generates an API key Secret automatically.
                             type: boolean
+                          existingSecret:
+                            description: |-
+                              existingSecret references a user-managed Secret that contains the API key.
+                              When set, its key is injected into the container instead of the operator-generated one.
+                              The referenced Secret must exist in the same namespace as the HermesAgent.
+                              The operator still generates its own Secret regardless of this field.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
                         type: object
                       raw:
                         description: raw holds the verbatim Hermes agent config.yml
                           as free-form YAML/JSON.
                         x-kubernetes-preserve-unknown-fields: true
+                      webhook:
+                        description: webhook configures the webhook ingress.
+                        properties:
+                          enabled:
+                            description: |-
+                              enabled activates the webhook listener (sets WEBHOOK_ENABLED=true).
+                              When enabled without secretRef, WEBHOOK_SECRET is injected from the
+                              operator-managed hermes Secret.
+                            type: boolean
+                          secretRef:
+                            description: |-
+                              secretRef references an existing Secret key to use as the HMAC secret
+                              instead of the operator-generated one. Use this to share a known value
+                              with external webhook senders, or to set "INSECURE_NO_AUTH" for testing.
+                            properties:
+                              key:
+                                description: The key of the secret to select from.  Must
+                                  be a valid secret key.
+                                type: string
+                              name:
+                                default: ""
+                                description: |-
+                                  Name of the referent.
+                                  This field is effectively required, but due to backwards compatibility is
+                                  allowed to be empty. Instances of this type with an empty value here are
+                                  almost certainly wrong.
+                                  More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                type: string
+                              optional:
+                                description: Specify whether the Secret or its key
+                                  must be defined
+                                type: boolean
+                            required:
+                            - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
                     type: object
                   crons:
                     description: crons is a list of scheduled jobs to manage via hermes


### PR DESCRIPTION
## Summary
- Regenerate the Helm chart and install manifests with `kubebuilder edit --plugins=helm/v2-alpha`, picking up the latest CRD changes (webhook field, secret lifecycle) in `dist/chart` and `dist/install.yaml`
- Bump chart version to 0.2.0 to match appVersion
- Document the chart regeneration step in CONTRIBUTING.md and drop the manual image build/deploy sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)