### PR TITLE
ci: validate PR titles against Conventional Commits spec

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,35 @@
+name: PR Title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - edited
+      # - synchronize (if you use required Actions)
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: |
+            feat
+            fix
+            docs
+            style
+            refactor
+            perf
+            test
+            build
+            ci
+            chore
+            revert
+          requireScope: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,32 @@ make test       # unit tests (no cluster required)
 make test-e2e   # e2e tests against a Kind cluster
 ```
 
+## Pull request titles
+
+PR titles must follow the [Conventional Commits](https://www.conventionalcommits.org/) format and are validated automatically by CI:
+
+```
+<type>: <short description>
+```
+
+Permitted types:
+
+| Type | When to use |
+|---|---|
+| `feat` | New feature |
+| `fix` | Bug fix |
+| `docs` | Documentation only |
+| `style` | Formatting, no logic change |
+| `refactor` | Code restructure, no feature/fix |
+| `perf` | Performance improvement |
+| `test` | Adding or fixing tests |
+| `build` | Build system changes |
+| `ci` | CI configuration changes |
+| `chore` | Maintenance tasks |
+| `revert` | Reverts a previous commit |
+
+Scopes are optional: `feat(api): add webhook field` is valid but `feat: add webhook field` is equally fine.
+
 ## Build and run locally
 
 ```sh


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/pr-title.yml` — uses `amannn/action-semantic-pull-request@v5` to block merges when a PR title doesn't follow the Conventional Commits format
- Triggers on `pull_request_target` with `opened`, `reopened`, and `edited` events (works for fork PRs without extra secret access)
- Documents the permitted types and format in `CONTRIBUTING.md`

## Permitted types

`feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert` — scopes are optional.

## Test plan

- [ ] Open a PR with a non-conforming title (e.g. `update stuff`) → `Validate PR title` check fails
- [ ] Edit the title to `fix: update stuff` → check passes
- [ ] Confirm the workflow appears in the PR's Checks tab

🤖 Generated with [Claude Code](https://claude.com/claude-code)