### PR TITLE
fix: set HOME to HERMES_HOME/home in all init containers

### DIFF
--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -341,7 +341,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 			Args:            []string{"chown -R 10000:10000 /opt/data"},
 			Env: append([]corev1.EnvVar{
 				{Name: "HERMES_HOME", Value: hermesHomeMount},
-				{Name: "HOME", Value: hermesHomeMount},
+				{Name: "HOME", Value: hermesHomeMount + "/home"},
 				{Name: "PATH", Value: hermesPathEnv},
 			}, ha.GetHermes().GetEnv()...),
 			EnvFrom: ha.GetHermes().GetEnvFrom(),
@@ -361,7 +361,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 			Args:            []string{buildConfigScript()},
 			Env: append([]corev1.EnvVar{
 				{Name: "HERMES_HOME", Value: hermesHomeMount},
-				{Name: "HOME", Value: hermesHomeMount},
+				{Name: "HOME", Value: hermesHomeMount + "/home"},
 				{Name: "PATH", Value: hermesPathEnv},
 			}, ha.GetHermes().GetEnv()...),
 			EnvFrom:         ha.GetHermes().GetEnvFrom(),
@@ -384,7 +384,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Args:            []string{buildWorkspaceScript()},
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
-			{Name: "HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount + "/home"},
 			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:         ha.GetHermes().GetEnvFrom(),
@@ -406,7 +406,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Args:            []string{buildPluginsScript(plugins)},
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
-			{Name: "HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount + "/home"},
 			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:         ha.GetHermes().GetEnvFrom(),
@@ -427,7 +427,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Args:            []string{buildSkillsScript(skills)},
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
-			{Name: "HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount + "/home"},
 			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:         ha.GetHermes().GetEnvFrom(),
@@ -448,7 +448,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Args:            []string{buildBundlesScript(bundles)},
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
-			{Name: "HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount + "/home"},
 			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:         ha.GetHermes().GetEnvFrom(),
@@ -469,7 +469,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Args:            []string{buildCronsScript(crons)},
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
-			{Name: "HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount + "/home"},
 			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:         ha.GetHermes().GetEnvFrom(),


### PR DESCRIPTION
## Summary

- The `HOME` env var in all init containers (`init-chown-data`, `init-config`, `init-workspace`, `init-plugins`, `init-skills`, `init-bundles`, `init-crons`) was incorrectly set to `HERMES_HOME` (`/opt/data`) instead of `HERMES_HOME/home` (`/opt/data/home`).
- The main `hermes-agent` container already had the correct value — this aligns all init containers with it.

## Test plan

- [x] Deploy a `HermesAgent` resource and confirm init containers start without home-directory-related errors
- [x] Verify tools that rely on `HOME` (e.g. pip/npm caches, shell rc files) resolve to `/opt/data/home` inside init containers

🤖 Generated with [Claude Code](https://claude.com/claude-code)