### PR TITLE
fix: use GetImage() for init-crons container instead of hardcoded image

### DIFF
--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -463,7 +463,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 	crons := ha.GetHermes().GetCrons()
 	initContainers = append(initContainers, corev1.Container{
 		Name:            "init-crons",
-		Image:           "nousresearch/hermes-agent:latest",
+		Image:           ha.GetHermes().GetImage(),
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Command:         []string{"/bin/sh", "-ec"},
 		Args:            []string{buildCronsScript(crons)},


### PR DESCRIPTION
## Summary

- The `init-crons` init container was using a hardcoded image `nousresearch/hermes-agent:latest` instead of `ha.GetHermes().GetImage()` like all other init containers in `buildHermesContainer`.

## What changed

Replaced the hardcoded image string with `ha.GetHermes().GetImage()` so the crons init container always uses the same image as configured in the `HermesAgent` spec, consistent with `init-config`, `init-workspace`, `init-plugins`, `init-skills`, and `init-bundles`.

## Reviewer notes

Trivial one-line fix — no behaviour change unless the user had configured a custom image, in which case this is a correctness fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)