### PR TITLE
fix: add ports to pod, service, and networkpolicy conditionally when apiServer or webhook is enabled

### DIFF
--- a/internal/infras/kubernetes.go
+++ b/internal/infras/kubernetes.go
@@ -277,6 +277,16 @@ func (k *KubernetesClient) UpdateServiceOwnedByHermesAgent(ctx context.Context, 
 	return k.client.Update(ctx, param.Service)
 }
 
+func (k *KubernetesClient) DeleteService(ctx context.Context, param usecase.DeleteServiceParam) error {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      param.NamespacedName.Name,
+			Namespace: param.NamespacedName.Namespace,
+		},
+	}
+	return client.IgnoreNotFound(k.client.Delete(ctx, svc))
+}
+
 func (k *KubernetesClient) GetIngress(ctx context.Context, param usecase.GetIngressParam) (*networkingv1.Ingress, error) {
 	ing := &networkingv1.Ingress{}
 	if err := k.client.Get(ctx, param.NamespacedName, ing); err != nil {

--- a/internal/usecase/hermesagent_networkpolicy.go
+++ b/internal/usecase/hermesagent_networkpolicy.go
@@ -83,12 +83,18 @@ func buildNetworkPolicy(ha *agentsv1alpha1.HermesAgent, np *agentsv1alpha1.Netwo
 }
 
 func buildNetworkPolicyIngress(ha *agentsv1alpha1.HermesAgent, np *agentsv1alpha1.NetworkPolicy) []networkingv1.NetworkPolicyIngressRule {
-	apiServer := intstr.FromInt32(ha.GetHermes().GetAPIServer().GetPort())
-	webhookPort := intstr.FromInt32(ha.GetHermes().GetWebhook().GetPort())
 	tcp := corev1.ProtocolTCP
-	ports := []networkingv1.NetworkPolicyPort{
-		{Protocol: &tcp, Port: &apiServer},
-		{Protocol: &tcp, Port: &webhookPort},
+	var ports []networkingv1.NetworkPolicyPort
+	if ha.GetHermes().GetAPIServer().IsEnabled() {
+		p := intstr.FromInt32(ha.GetHermes().GetAPIServer().GetPort())
+		ports = append(ports, networkingv1.NetworkPolicyPort{Protocol: &tcp, Port: &p})
+	}
+	if ha.GetHermes().GetWebhook().IsEnabled() {
+		p := intstr.FromInt32(ha.GetHermes().GetWebhook().GetPort())
+		ports = append(ports, networkingv1.NetworkPolicyPort{Protocol: &tcp, Port: &p})
+	}
+	if len(ports) == 0 {
+		return nil
 	}
 
 	peers := make([]networkingv1.NetworkPolicyPeer, 0, len(np.AllowedIngressCIDRs)+len(np.AllowedIngressNamespaces))

--- a/internal/usecase/hermesagent_service.go
+++ b/internal/usecase/hermesagent_service.go
@@ -23,6 +23,20 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 	}
 
 	desired := buildService(ha)
+	if len(desired.Spec.Ports) == 0 {
+		if existing != nil {
+			if err := u.kube.DeleteService(ctx, DeleteServiceParam{NamespacedName: nsName}); err != nil {
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+			}
+			u.tel.Debug(ctx, "Service deleted (no ports configured)", "namespacedName", nsName)
+		}
+		ha.Status.ManagedResources.Service = ""
+		if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+		}
+		return ctrl.Result{}, nil
+	}
+
 	if existing != nil {
 		desired.ResourceVersion = existing.ResourceVersion
 		// ClusterIP is immutable; carry it over from the existing Service.
@@ -71,19 +85,22 @@ func buildService(ha *agentsv1alpha1.HermesAgent) *corev1.Service {
 func buildServicePorts(ha *agentsv1alpha1.HermesAgent, svc *agentsv1alpha1.Service) []corev1.ServicePort {
 	apiServer := ha.GetHermes().GetAPIServer()
 	webhook := ha.GetHermes().GetWebhook()
-	ports := []corev1.ServicePort{
-		{
+	var ports []corev1.ServicePort
+	if apiServer.IsEnabled() {
+		ports = append(ports, corev1.ServicePort{
 			Name:       apiServer.GetPortName(),
 			Port:       apiServer.GetPort(),
 			TargetPort: intstr.FromInt32(apiServer.GetPort()),
 			Protocol:   corev1.ProtocolTCP,
-		},
-		{
+		})
+	}
+	if webhook.IsEnabled() {
+		ports = append(ports, corev1.ServicePort{
 			Name:       webhook.GetPortName(),
 			Port:       webhook.GetPort(),
 			TargetPort: intstr.FromInt32(webhook.GetPort()),
 			Protocol:   corev1.ProtocolTCP,
-		},
+		})
 	}
 	if svc == nil {
 		return ports

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -212,18 +212,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		ImagePullPolicy: corev1.PullIfNotPresent,
 		Args:            []string{"gateway", "run"},
 		WorkingDir:      "/opt/hermes",
-		Ports: append([]corev1.ContainerPort{
-			{
-				Name:          apiServer.GetPortName(),
-				ContainerPort: apiServer.GetPort(),
-				Protocol:      corev1.ProtocolTCP,
-			},
-			{
-				Name:          ha.GetHermes().GetWebhook().GetPortName(),
-				ContainerPort: ha.GetHermes().GetWebhook().GetPort(),
-				Protocol:      corev1.ProtocolTCP,
-			},
-		}, ha.GetHermes().GetPorts()...),
+		Ports:           ha.GetHermes().GetPorts(),
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
 			{Name: "HOME", Value: hermesHomeMount + "/home"},
@@ -276,6 +265,11 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 
 	// API server configuration
 	if apiServer.IsEnabled() {
+		container.Ports = append(container.Ports, corev1.ContainerPort{
+			Name:          apiServer.GetPortName(),
+			ContainerPort: apiServer.GetPort(),
+			Protocol:      corev1.ProtocolTCP,
+		})
 		apiKeyRef := &corev1.SecretKeySelector{
 			LocalObjectReference: corev1.LocalObjectReference{Name: ha.GetHermesName()},
 			Key:                  "API_SERVER_KEY",
@@ -304,6 +298,11 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 
 	// Webhook configuration
 	if ha.GetHermes().GetWebhook().IsEnabled() {
+		container.Ports = append(container.Ports, corev1.ContainerPort{
+			Name:          ha.GetHermes().GetWebhook().GetPortName(),
+			ContainerPort: ha.GetHermes().GetWebhook().GetPort(),
+			Protocol:      corev1.ProtocolTCP,
+		})
 		secretRef := ha.GetHermes().GetWebhook().GetSecretRef()
 		if secretRef == nil {
 			secretRef = &corev1.SecretKeySelector{

--- a/internal/usecase/interface.go
+++ b/internal/usecase/interface.go
@@ -88,6 +88,7 @@ type Kubernetes interface {
 	GetService(ctx context.Context, param GetServiceParam) (*corev1.Service, error)
 	CreateServiceOwnedByHermesAgent(ctx context.Context, param CreateServiceOfHermesAgentParam) error
 	UpdateServiceOwnedByHermesAgent(ctx context.Context, param UpdateServiceParam) error
+	DeleteService(ctx context.Context, param DeleteServiceParam) error
 
 	GetIngress(ctx context.Context, param GetIngressParam) (*networkingv1.Ingress, error)
 	CreateIngressOwnedByHermesAgent(ctx context.Context, param CreateIngressOfHermesAgentParam) error
@@ -228,6 +229,10 @@ type CreateServiceOfHermesAgentParam struct {
 type UpdateServiceParam struct {
 	HermesAgent *agentsv1alpha1.HermesAgent
 	Service     *corev1.Service
+}
+
+type DeleteServiceParam struct {
+	NamespacedName types.NamespacedName
 }
 
 type GetIngressParam struct {


### PR DESCRIPTION
## Summary

- Container ports, Service ports, and NetworkPolicy ingress ports for `apiServer` and `webhook` are now only added when the respective feature is enabled (`IsEnabled()` returns true), rather than unconditionally.
- When both features are disabled and no extra ports are configured, the Service is deleted (if it exists) and the status is cleared — avoiding the `spec.ports: Required value` Kubernetes validation error.

## What changed

**`internal/usecase/hermesagent_statefulset.go`**
Container ports for `apiServer` and `webhook` are now appended inside the existing `if apiServer.IsEnabled()` and `if ha.GetHermes().GetWebhook().IsEnabled()` blocks alongside the env var configuration, instead of an unconditional inline slice.

**`internal/usecase/hermesagent_service.go`**
Service ports are built conditionally. When the resulting ports slice is empty, `reconcileService` deletes any existing Service, clears `ManagedResources.Service`, and calls `UpdateHermesAgentStatus` — matching the pattern in `reconcileIngress`.

**`internal/usecase/hermesagent_networkpolicy.go`**
NetworkPolicy ingress ports are built conditionally. When both features are disabled the function returns `nil` (no ingress rule), avoiding the Kubernetes footgun where an empty `ports` list means "allow all ports".

**`internal/usecase/interface.go` / `internal/infras/kubernetes.go`**
Added `DeleteService` to the `Kubernetes` interface and its implementation, following the same pattern as `DeleteIngress`.

## Reviewer notes

The status update on the empty-ports path is called unconditionally (not only when a Service was actually deleted), matching how `reconcileIngress` handles its disabled branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)