### PR TITLE
refactor: remove hardcoded PATH env var from all containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,8 +437,6 @@ They aren't. The operator only manages what is explicitly declared in the `Herme
 
 Only the `HERMES_HOME` path (`/opt/data`) is persisted across pod restarts. Anything that needs to survive a restart must be placed under `HERMES_HOME`. The operator sets `HOME=/opt/data/home` so tools that respect `$HOME` will write there automatically.
 
-To make binaries persistent and immediately executable, place them under `/opt/data/.local/bin` — that directory is included in the container's default `PATH`.
-
 **Q: Why does the Hermes container run as root?**
 
 The official Hermes image uses [s6-overlay](https://github.com/just-containers/s6-overlay), which requires the process to start as root for service supervision setup. Once initialisation is complete, s6-overlay drops privileges and runs the agent as the `hermes` user (`10000:10000`).

--- a/README.md
+++ b/README.md
@@ -437,6 +437,8 @@ They aren't. The operator only manages what is explicitly declared in the `Herme
 
 Only the `HERMES_HOME` path (`/opt/data`) is persisted across pod restarts. Anything that needs to survive a restart must be placed under `HERMES_HOME`. The operator sets `HOME=/opt/data/home` so tools that respect `$HOME` will write there automatically.
 
+`/opt/data/.local/bin` is included in the container's default `PATH`, so binaries installed there are both persistent and immediately executable without any extra configuration.
+
 **Q: Why does the Hermes container run as root?**
 
 The official Hermes image uses [s6-overlay](https://github.com/just-containers/s6-overlay), which requires the process to start as root for service supervision setup. Once initialisation is complete, s6-overlay drops privileges and runs the agent as the `hermes` user (`10000:10000`).

--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ They aren't. The operator only manages what is explicitly declared in the `Herme
 
 Only the `HERMES_HOME` path (`/opt/data`) is persisted across pod restarts. Anything that needs to survive a restart must be placed under `HERMES_HOME`. The operator sets `HOME=/opt/data/home` so tools that respect `$HOME` will write there automatically.
 
-`/opt/data/.local/bin` is included in the container's default `PATH`, so binaries installed there are both persistent and immediately executable without any extra configuration.
+To make binaries persistent and immediately executable, place them under `/opt/data/.local/bin` — that directory is included in the container's default `PATH`.
 
 **Q: Why does the Hermes container run as root?**
 

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -189,8 +189,6 @@ func buildInitContainerSecurityContext() *corev1.SecurityContext {
 // and volumes/PVCs for persistence, bootstrap config, and shared memory.
 func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSet) *appsv1.StatefulSet {
 	const (
-		hermesDefaultPathEnv  = "/opt/data/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-		hermesPathEnv         = hermesDefaultPathEnv + ":/opt/hermes/.venv/bin"
 		hermesHomeVolume      = "hermes-data"
 		hermesHomeMount       = "/opt/data"
 		hermesDSHMVolume      = "dshm"
@@ -216,7 +214,6 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
 			{Name: "HOME", Value: hermesHomeMount + "/home"},
-			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:   ha.GetHermes().GetEnvFrom(),
 		Resources: ha.GetHermes().GetResources(),
@@ -362,7 +359,6 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 			Env: append([]corev1.EnvVar{
 				{Name: "HERMES_HOME", Value: hermesHomeMount},
 				{Name: "HOME", Value: hermesHomeMount + "/home"},
-				{Name: "PATH", Value: hermesPathEnv},
 			}, ha.GetHermes().GetEnv()...),
 			EnvFrom: ha.GetHermes().GetEnvFrom(),
 			VolumeMounts: []corev1.VolumeMount{
@@ -382,7 +378,6 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 			Env: append([]corev1.EnvVar{
 				{Name: "HERMES_HOME", Value: hermesHomeMount},
 				{Name: "HOME", Value: hermesHomeMount + "/home"},
-				{Name: "PATH", Value: hermesPathEnv},
 			}, ha.GetHermes().GetEnv()...),
 			EnvFrom:         ha.GetHermes().GetEnvFrom(),
 			SecurityContext: buildInitContainerSecurityContext(),
@@ -405,7 +400,6 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
 			{Name: "HOME", Value: hermesHomeMount + "/home"},
-			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:         ha.GetHermes().GetEnvFrom(),
 		SecurityContext: buildInitContainerSecurityContext(),
@@ -427,7 +421,6 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
 			{Name: "HOME", Value: hermesHomeMount + "/home"},
-			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:         ha.GetHermes().GetEnvFrom(),
 		SecurityContext: buildInitContainerSecurityContext(),
@@ -448,7 +441,6 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
 			{Name: "HOME", Value: hermesHomeMount + "/home"},
-			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:         ha.GetHermes().GetEnvFrom(),
 		SecurityContext: buildInitContainerSecurityContext(),
@@ -469,7 +461,6 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
 			{Name: "HOME", Value: hermesHomeMount + "/home"},
-			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:         ha.GetHermes().GetEnvFrom(),
 		SecurityContext: buildInitContainerSecurityContext(),
@@ -490,7 +481,6 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
 			{Name: "HOME", Value: hermesHomeMount + "/home"},
-			{Name: "PATH", Value: hermesPathEnv},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:         ha.GetHermes().GetEnvFrom(),
 		SecurityContext: buildInitContainerSecurityContext(),


### PR DESCRIPTION
## What changed

Removed `hermesDefaultPathEnv` and `hermesPathEnv` constants from `buildHermesContainer` and stopped injecting a hardcoded `PATH` environment variable into the main `hermes-agent` container and all init containers (`init-chown-data`, `init-config`, `init-workspace`, `init-plugins`, `init-skills`, `init-bundles`, `init-crons`).

## Why

The container image already provides a correct `PATH` via its own default environment. Hardcoding it in the operator was redundant and fragile — any change to the image's venv layout or bin directories would require an operator update too.

## Reviewer notes

No behavioral change expected: the image's default `PATH` covers the same directories. Users who need a custom `PATH` can still supply it via `.spec.hermes.env`.