### PR TITLE
fix: fix plugin removal command path and hardcoded `/opt/data` in cron script (#23)

### DIFF
--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -798,7 +798,7 @@ if [ -f "$MANIFEST" ]; then
     [ -z "$name" ] && continue
     case "$name" in
       %s) ;;
-      *) /hermes plugins remove "$name" || true ;;
+      *) hermes plugins remove "$name" || true ;;
     esac
   done < "$MANIFEST"
 fi
@@ -975,13 +975,13 @@ func buildCronsScript(crons []agentsv1alpha1.HermesCron) string {
 	manifestContent := strings.Join(desiredNames, "\n")
 
 	return fmt.Sprintf(`set -eu
-MANIFEST="/opt/data/.hermes-agent-operator/crons"
-mkdir -p "/opt/data/.hermes-agent-operator"
+MANIFEST="$HERMES_HOME/.hermes-agent-operator/crons"
+mkdir -p "$HERMES_HOME/.hermes-agent-operator"
 
 get_job_id() {
   python3 - "$1" <<'PY'
 import json, os, sys
-p = "/opt/data/cron/jobs.json"
+p = os.environ.get("HERMES_HOME", "/opt/data") + "/cron/jobs.json"
 if not os.path.exists(p):
     sys.exit(0)
 with open(p) as f:

--- a/internal/usecase/hermesagent_statefulset_test.go
+++ b/internal/usecase/hermesagent_statefulset_test.go
@@ -50,6 +50,18 @@ func TestBuildPluginsScript(t *testing.T) {
 		}
 	})
 
+	t.Run("remove command uses bare hermes not absolute path", func(t *testing.T) {
+		got := buildPluginsScript([]agentsv1alpha1.HermesPlugin{
+			{Identifier: "owner/hermes-plugin-a"},
+		})
+		if strings.Contains(got, "/hermes ") {
+			t.Errorf("expected bare 'hermes' command, not absolute '/hermes' path, got:\n%s", got)
+		}
+		if !strings.Contains(got, `hermes plugins remove "$name"`) {
+			t.Errorf("expected plugin remove command in script, got:\n%s", got)
+		}
+	})
+
 	t.Run("multiple plugins build case pattern and manifest", func(t *testing.T) {
 		got := buildPluginsScript([]agentsv1alpha1.HermesPlugin{
 			{Identifier: "owner/hermes-plugin-a"},


### PR DESCRIPTION
## Summary

- **Fix plugin removal silently failing**: `buildPluginsScript` used `/hermes plugins remove` — an absolute path to a non-existent file — instead of `hermes` (PATH lookup). The `|| true` masked it silently, so stale plugins were never uninstalled when removed from `spec.hermes.plugins`.
- **Fix hardcoded `/opt/data` in `buildCronsScript`**: The cron manifest paths and the embedded Python snippet used hardcoded `/opt/data` instead of `$HERMES_HOME`, inconsistent with every other script.
- **Add regression test**: New test case in `TestBuildPluginsScript` asserts that the removal line uses bare `hermes`, not `/hermes`.

## Root cause

`/opt/hermes` is the baked-in image directory — it is ephemeral in the sense that writes to its writable container layer don't survive pod restarts. Scripts in init containers must use `hermes` (PATH lookup via image ENV, which includes `/opt/hermes/.venv/bin`) rather than absolute paths. `/hermes` at the filesystem root does not exist in the Hermes image.

Every other generated script (`buildSkillsScript`, `buildBundlesScript`, `buildCronsScript`) already used the bare command; `buildPluginsScript` was the single inconsistency.

## Test plan

- [ ] `make test` passes with the new regression test
- [ ] Deploy with a `spec.hermes.plugins` entry, confirm install works
- [ ] Remove the plugin from the spec, confirm it is actually uninstalled from the agent (previously silently failed)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)