### PR TITLE
feat: add `pythonPackages` for pre-installing Python packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ kubectl get pods -l app.kubernetes.io/instance=my-agent
 - [`hermes.config`](#hermesconfig)
 - [`hermes.storage`](#hermesstorage)
 - [`hermes.workspace`](#hermesworkspace)
+- [`hermes.pythonPackages`](#hermespythonpackages)
 - [`hermes.plugins`](#hermesplugins)
 - [`hermes.skills`](#hermesskills)
 - [`hermes.crons`](#hermescrons)
@@ -148,6 +149,25 @@ hermes:
         # My Custom Skill
         ...
 ```
+
+
+### `hermes.pythonPackages`
+
+Pre-install Python packages before the agent starts. Each entry is a [pip specifier](https://pip.pypa.io/en/stable/reference/requirement-specifiers/) — bare name, version-pinned, or extras.
+
+Packages are installed into `$HERMES_HOME/.python-packages` (under `/opt/data`, the persistent volume) and made available to the agent via `PYTHONPATH`. Because the installation runs in an init container that executes on every pod start, packages are always present even when persistence is disabled. When a PVC is attached, the operator skips reinstalling if the desired set has not changed since the last start.
+
+Removing a package from the list wipes and reinstalls the remaining set on the next reconcile, so the installed state always matches the declaration.
+
+```yaml
+hermes:
+  pythonPackages:                  # optional; omit if no extra packages are needed
+    - requests
+    - pandas==2.1.0
+    - "beautifulsoup4[lxml]"
+```
+
+> **Note:** Packages here are available to Python code run *by* the agent (tool execution, scripts, etc.). They do not affect the Hermes agent process itself, which uses its own virtual environment at `/opt/hermes/.venv`.
 
 
 ### `hermes.plugins`

--- a/api/v1alpha1/hermesagent_types.go
+++ b/api/v1alpha1/hermesagent_types.go
@@ -472,6 +472,11 @@ type Hermes struct {
 	// workspace defines files to seed in the agent's home directory.
 	// +optional
 	Workspace *HermesWorkspace `json:"workspace,omitempty"`
+	// pythonPackages is a list of Python package specifiers to pre-install before the
+	// agent starts (e.g. "requests", "pandas==2.1.0"). Packages are installed into
+	// $HERMES_HOME/.python-packages and made available via PYTHONPATH.
+	// +optional
+	PythonPackages []string `json:"pythonPackages,omitempty"`
 	// plugins is a list of plugins to install in the Hermes agent.
 	// +optional
 	Plugins []HermesPlugin `json:"plugins,omitempty"`
@@ -578,6 +583,13 @@ func (h *Hermes) GetWorkspace() *HermesWorkspace {
 		return nil
 	}
 	return h.Workspace
+}
+
+func (h *Hermes) GetPythonPackages() []string {
+	if h == nil {
+		return nil
+	}
+	return h.PythonPackages
 }
 
 func (h *Hermes) GetPlugins() []HermesPlugin {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -125,6 +125,11 @@ func (in *Hermes) DeepCopyInto(out *Hermes) {
 		*out = new(HermesWorkspace)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.PythonPackages != nil {
+		in, out := &in.PythonPackages, &out.PythonPackages
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Plugins != nil {
 		in, out := &in.Plugins, &out.Plugins
 		*out = make([]HermesPlugin, len(*in))

--- a/config/crd/bases/agents.hermeum.app_hermesagents.yaml
+++ b/config/crd/bases/agents.hermeum.app_hermesagents.yaml
@@ -2876,6 +2876,14 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  pythonPackages:
+                    description: |-
+                      pythonPackages is a list of Python package specifiers to pre-install before the
+                      agent starts (e.g. "requests", "pandas==2.1.0"). Packages are installed into
+                      $HERMES_HOME/.python-packages and made available via PYTHONPATH.
+                    items:
+                      type: string
+                    type: array
                   resources:
                     description: resources overrides the resource requests and limits
                       for the hermes-agent container.

--- a/dist/chart/templates/crd/hermesagents.agents.hermeum.app.yaml
+++ b/dist/chart/templates/crd/hermesagents.agents.hermeum.app.yaml
@@ -2335,9 +2335,20 @@ spec:
                           management required. Set existingSecret to supply your own Secret instead.
                           The Secret is persisted across reconciles; enabling the server injects it into the container.
                         properties:
+                          corsOrigins:
+                            description: |-
+                              corsOrigins lists the browser origins allowed to call the API server
+                              (sets API_SERVER_CORS_ORIGINS as a comma-separated list when enabled).
+                              CORS stays disabled when empty. Keep this narrow: the API grants access
+                              to the agent's full toolset.
+                            items:
+                              type: string
+                            type: array
                           enabled:
                             description: |-
-                              enabled turns on the gateway API server (sets API_SERVER_ENABLED=true).
+                              enabled turns on the gateway API server (sets API_SERVER_ENABLED=true)
+                              bound to all interfaces (sets API_SERVER_HOST=0.0.0.0) so that the
+                              Service can route to it.
                               The operator always generates an API key Secret automatically.
                             type: boolean
                           existingSecret:
@@ -2368,6 +2379,16 @@ spec:
                             - key
                             type: object
                             x-kubernetes-map-type: atomic
+                          port:
+                            default: 8642
+                            description: |-
+                              port is the port the API server listens on (sets API_SERVER_PORT when enabled).
+                              The container port, the Service port, and the NetworkPolicy ingress rule
+                              follow this value.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
                         type: object
                       raw:
                         description: raw holds the verbatim Hermes agent config.yml
@@ -2382,6 +2403,16 @@ spec:
                               When enabled without secretRef, WEBHOOK_SECRET is injected from the
                               operator-managed hermes Secret.
                             type: boolean
+                          port:
+                            default: 8644
+                            description: |-
+                              port is the port the webhook listener binds on (sets WEBHOOK_PORT when enabled).
+                              The container port, the Service port, and the NetworkPolicy ingress rule
+                              follow this value.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
                           secretRef:
                             description: |-
                               secretRef references an existing Secret key to use as the HMAC secret
@@ -2715,7 +2746,8 @@ spec:
                   ports:
                     description: |-
                       ports declares additional container ports on the hermes-agent container.
-                      The gateway port (8642) is always included and should not be repeated here.
+                      The API server port (config.apiServer.port, default 8642) is always
+                      included and should not be repeated here.
                     items:
                       description: ContainerPort represents a network port in a single
                         container.
@@ -2756,14 +2788,15 @@ spec:
                   probes:
                     description: |-
                       probes overrides the health probe configuration for the hermes-agent container.
-                      Probes target the GET /health endpoint on the gateway port.
+                      Probes exec `hermes gateway status` inside the container, which works
+                      regardless of which ports the gateway listens on.
                     properties:
                       liveness:
                         description: liveness configures the liveness probe. Disabled
-                          unless set.
+                          unless enabled.
                         properties:
                           enabled:
-                            default: true
+                            default: false
                             description: enabled enables the probe.
                             type: boolean
                           failureThreshold:
@@ -2788,11 +2821,11 @@ spec:
                             type: integer
                         type: object
                       readiness:
-                        description: readiness configures the readiness probe. Enabled
-                          by default.
+                        description: readiness configures the readiness probe. Disabled
+                          unless enabled.
                         properties:
                           enabled:
-                            default: true
+                            default: false
                             description: enabled enables the probe.
                             type: boolean
                           failureThreshold:
@@ -2818,10 +2851,10 @@ spec:
                         type: object
                       startup:
                         description: startup configures the startup probe. Disabled
-                          unless set.
+                          unless enabled.
                         properties:
                           enabled:
-                            default: true
+                            default: false
                             description: enabled enables the probe.
                             type: boolean
                           failureThreshold:
@@ -2846,6 +2879,14 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  pythonPackages:
+                    description: |-
+                      pythonPackages is a list of Python package specifiers to pre-install before the
+                      agent starts (e.g. "requests", "pandas==2.1.0"). Packages are installed into
+                      $HERMES_HOME/.python-packages and made available via PYTHONPATH.
+                    items:
+                      type: string
+                    type: array
                   resources:
                     description: resources overrides the resource requests and limits
                       for the hermes-agent container.
@@ -4547,17 +4588,20 @@ spec:
                                     - ImplementationSpecific
                                     type: string
                                   port:
-                                    description: |-
-                                      port is the backend service port number to route traffic to.
-                                      Defaults to the gateway port (8642) when not set.
+                                    description: port is the backend service port
+                                      number to route traffic to.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
                                     type: integer
+                                required:
+                                - port
                                 type: object
+                              minItems: 1
                               type: array
                           required:
                           - host
+                          - paths
                           type: object
                         type: array
                       tls:
@@ -4589,9 +4633,9 @@ spec:
                         type: object
                       ports:
                         description: |-
-                          ports defines custom ports exposed on the Service.
-                          When set, these replace the default gateway port.
-                          When empty, the operator creates the default gateway port (8642).
+                          ports defines additional ports exposed on the Service.
+                          The API server port (config.apiServer.port, default 8642) is always
+                          exposed and should not be repeated here.
                         items:
                           description: ServicePort defines a port exposed by the Service.
                           properties:

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -2340,9 +2340,20 @@ spec:
                           management required. Set existingSecret to supply your own Secret instead.
                           The Secret is persisted across reconciles; enabling the server injects it into the container.
                         properties:
+                          corsOrigins:
+                            description: |-
+                              corsOrigins lists the browser origins allowed to call the API server
+                              (sets API_SERVER_CORS_ORIGINS as a comma-separated list when enabled).
+                              CORS stays disabled when empty. Keep this narrow: the API grants access
+                              to the agent's full toolset.
+                            items:
+                              type: string
+                            type: array
                           enabled:
                             description: |-
-                              enabled turns on the gateway API server (sets API_SERVER_ENABLED=true).
+                              enabled turns on the gateway API server (sets API_SERVER_ENABLED=true)
+                              bound to all interfaces (sets API_SERVER_HOST=0.0.0.0) so that the
+                              Service can route to it.
                               The operator always generates an API key Secret automatically.
                             type: boolean
                           existingSecret:
@@ -2373,6 +2384,16 @@ spec:
                             - key
                             type: object
                             x-kubernetes-map-type: atomic
+                          port:
+                            default: 8642
+                            description: |-
+                              port is the port the API server listens on (sets API_SERVER_PORT when enabled).
+                              The container port, the Service port, and the NetworkPolicy ingress rule
+                              follow this value.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
                         type: object
                       raw:
                         description: raw holds the verbatim Hermes agent config.yml
@@ -2387,6 +2408,16 @@ spec:
                               When enabled without secretRef, WEBHOOK_SECRET is injected from the
                               operator-managed hermes Secret.
                             type: boolean
+                          port:
+                            default: 8644
+                            description: |-
+                              port is the port the webhook listener binds on (sets WEBHOOK_PORT when enabled).
+                              The container port, the Service port, and the NetworkPolicy ingress rule
+                              follow this value.
+                            format: int32
+                            maximum: 65535
+                            minimum: 1
+                            type: integer
                           secretRef:
                             description: |-
                               secretRef references an existing Secret key to use as the HMAC secret
@@ -2720,7 +2751,8 @@ spec:
                   ports:
                     description: |-
                       ports declares additional container ports on the hermes-agent container.
-                      The gateway port (8642) is always included and should not be repeated here.
+                      The API server port (config.apiServer.port, default 8642) is always
+                      included and should not be repeated here.
                     items:
                       description: ContainerPort represents a network port in a single
                         container.
@@ -2761,14 +2793,15 @@ spec:
                   probes:
                     description: |-
                       probes overrides the health probe configuration for the hermes-agent container.
-                      Probes target the GET /health endpoint on the gateway port.
+                      Probes exec `hermes gateway status` inside the container, which works
+                      regardless of which ports the gateway listens on.
                     properties:
                       liveness:
                         description: liveness configures the liveness probe. Disabled
-                          unless set.
+                          unless enabled.
                         properties:
                           enabled:
-                            default: true
+                            default: false
                             description: enabled enables the probe.
                             type: boolean
                           failureThreshold:
@@ -2793,11 +2826,11 @@ spec:
                             type: integer
                         type: object
                       readiness:
-                        description: readiness configures the readiness probe. Enabled
-                          by default.
+                        description: readiness configures the readiness probe. Disabled
+                          unless enabled.
                         properties:
                           enabled:
-                            default: true
+                            default: false
                             description: enabled enables the probe.
                             type: boolean
                           failureThreshold:
@@ -2823,10 +2856,10 @@ spec:
                         type: object
                       startup:
                         description: startup configures the startup probe. Disabled
-                          unless set.
+                          unless enabled.
                         properties:
                           enabled:
-                            default: true
+                            default: false
                             description: enabled enables the probe.
                             type: boolean
                           failureThreshold:
@@ -2851,6 +2884,14 @@ spec:
                             type: integer
                         type: object
                     type: object
+                  pythonPackages:
+                    description: |-
+                      pythonPackages is a list of Python package specifiers to pre-install before the
+                      agent starts (e.g. "requests", "pandas==2.1.0"). Packages are installed into
+                      $HERMES_HOME/.python-packages and made available via PYTHONPATH.
+                    items:
+                      type: string
+                    type: array
                   resources:
                     description: resources overrides the resource requests and limits
                       for the hermes-agent container.
@@ -4552,17 +4593,20 @@ spec:
                                     - ImplementationSpecific
                                     type: string
                                   port:
-                                    description: |-
-                                      port is the backend service port number to route traffic to.
-                                      Defaults to the gateway port (8642) when not set.
+                                    description: port is the backend service port
+                                      number to route traffic to.
                                     format: int32
                                     maximum: 65535
                                     minimum: 1
                                     type: integer
+                                required:
+                                - port
                                 type: object
+                              minItems: 1
                               type: array
                           required:
                           - host
+                          - paths
                           type: object
                         type: array
                       tls:
@@ -4594,9 +4638,9 @@ spec:
                         type: object
                       ports:
                         description: |-
-                          ports defines custom ports exposed on the Service.
-                          When set, these replace the default gateway port.
-                          When empty, the operator creates the default gateway port (8642).
+                          ports defines additional ports exposed on the Service.
+                          The API server port (config.apiServer.port, default 8642) is always
+                          exposed and should not be repeated here.
                         items:
                           description: ServicePort defines a port exposed by the Service.
                           properties:

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -214,6 +214,7 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		Env: append([]corev1.EnvVar{
 			{Name: "HERMES_HOME", Value: hermesHomeMount},
 			{Name: "HOME", Value: hermesHomeMount + "/home"},
+			{Name: "PYTHONPATH", Value: hermesHomeMount + "/.python-packages"},
 		}, ha.GetHermes().GetEnv()...),
 		EnvFrom:   ha.GetHermes().GetEnvFrom(),
 		Resources: ha.GetHermes().GetResources(),
@@ -406,6 +407,26 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: hermesHomeVolume, MountPath: hermesHomeMount},
 			{Name: hermesBootstrapVolume, MountPath: hermesBootstrapMount, ReadOnly: true},
+			{Name: hermesTmpVolume, MountPath: hermesTmpMount},
+		},
+	})
+
+	// python-packages: init container installs desired packages into $HERMES_HOME/.python-packages.
+	pkgs := ha.GetHermes().GetPythonPackages()
+	initContainers = append(initContainers, corev1.Container{
+		Name:            "init-python-packages",
+		Image:           ha.GetHermes().GetImage(),
+		ImagePullPolicy: corev1.PullIfNotPresent,
+		Command:         []string{"/bin/sh", "-ec"},
+		Args:            []string{buildPythonPackagesScript(pkgs)},
+		Env: append([]corev1.EnvVar{
+			{Name: "HERMES_HOME", Value: hermesHomeMount},
+			{Name: "HOME", Value: hermesHomeMount + "/home"},
+		}, ha.GetHermes().GetEnv()...),
+		EnvFrom:         ha.GetHermes().GetEnvFrom(),
+		SecurityContext: buildInitContainerSecurityContext(),
+		VolumeMounts: []corev1.VolumeMount{
+			{Name: hermesHomeVolume, MountPath: hermesHomeMount},
 			{Name: hermesTmpVolume, MountPath: hermesTmpMount},
 		},
 	})
@@ -931,6 +952,42 @@ cat > "$MANIFEST" << 'BUNDLES_EOF'
 %s
 BUNDLES_EOF
 `, casePattern, createScript, manifestContent)
+}
+
+func buildPythonPackagesScript(packages []string) string {
+	if len(packages) == 0 {
+		return "echo 'No Python packages configured'"
+	}
+
+	quoted := make([]string, len(packages))
+	for i, p := range packages {
+		quoted[i] = fmt.Sprintf("%q", p)
+	}
+	installCmd := "uv pip install --python /opt/hermes/.venv/bin/python --target \"$TARGET\" " +
+		strings.Join(quoted, " ")
+	manifestContent := strings.Join(packages, "\n")
+
+	return fmt.Sprintf(`set -eu
+TARGET="$HERMES_HOME/.python-packages"
+MANIFEST="$HERMES_HOME/.hermes-agent-operator/python-packages"
+mkdir -p "$HERMES_HOME/.hermes-agent-operator"
+
+DESIRED=$(cat <<'PKGS_EOF'
+%s
+PKGS_EOF
+)
+
+if [ -f "$MANIFEST" ] && [ "$(cat "$MANIFEST")" = "$DESIRED" ]; then
+  echo "Python packages up-to-date, skipping"
+  exit 0
+fi
+
+rm -rf "$TARGET"
+mkdir -p "$TARGET"
+%s
+
+printf '%%s' "$DESIRED" > "$MANIFEST"
+`, manifestContent, installCmd)
 }
 
 func buildCronsScript(crons []agentsv1alpha1.HermesCron) string {


### PR DESCRIPTION
## Summary

- Adds `spec.hermes.pythonPackages` — a declarative list of pip specifiers (e.g. `requests`, `pandas==2.1.0`) that are pre-installed before the agent starts
- Packages are installed into `$HERMES_HOME/.python-packages` (inside the `/opt/data` persistent volume) via an `init-python-packages` init container, and exposed to the agent via `PYTHONPATH`
- Follows the same manifest-based reconciliation pattern as `plugins`, `skills`, `bundles`, and `crons`: reinstalls only when the desired set changes, wipes and reinstalls on any diff

## What changed

**`api/v1alpha1/hermesagent_types.go`**
- Added `PythonPackages []string` field to the `Hermes` struct (ordered before `Plugins` to match init container execution order)
- Added `GetPythonPackages()` accessor

**`internal/usecase/hermesagent_statefulset.go`**
- Injected `PYTHONPATH=/opt/data/.python-packages` into the main container base env (additive — does not suppress the venv's own site-packages)
- Added `init-python-packages` init container, executed before `init-plugins`
- Added `buildPythonPackagesScript()`: uses `uv pip install --python /opt/hermes/.venv/bin/python --target` into the data volume, with manifest comparison for idempotency

**`README.md`** — new `hermes.pythonPackages` section with usage example

**`dist/`** — Helm chart and install manifest regenerated via `kubebuilder edit --plugins=helm/v2-alpha`

## Reviewer notes

- `PYTHONPATH` is additive: `sys.path` becomes `[..., /opt/data/.python-packages, /opt/hermes/.venv/lib/python3.13/site-packages, ...]`. The venv is fully accessible. Packages in `PYTHONPATH` take priority on name collision (desired for user overrides).
- With PVC persistence enabled, the manifest check makes subsequent restarts near-instant (no reinstall if the list hasn't changed). Without a PVC, packages are reinstalled on every pod start — same behaviour as plugins/skills.
- Closes #23

## Test plan

- [x] Apply a `HermesAgent` with `spec.hermes.pythonPackages: [requests, pandas]`
- [x] `kubectl logs <pod> -c init-python-packages` shows successful install
- [x] `kubectl exec <pod> -c hermes-agent -- /opt/hermes/.venv/bin/python -c "import requests; print(requests.__version__)"` succeeds
- [x] `kubectl exec <pod> -c hermes-agent -- env | grep PYTHONPATH` returns `/opt/data/.python-packages`
- [x] Restart pod with same spec → init container logs "Python packages up-to-date, skipping"
- [x] Remove a package from spec → init container wipes and reinstalls remaining set

🤖 Generated with [Claude Code](https://claude.com/claude-code)