### PR TITLE
fix: update ManagedResources status only on creation, not on update

### DIFF
--- a/internal/usecase/hermesagent_hermes_configmap.go
+++ b/internal/usecase/hermesagent_hermes_configmap.go
@@ -34,7 +34,6 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 
 	if cm != nil {
 		if configMapDataEqual(desired, cm) {
-			ha.Status.ManagedResources.HermesConfigMap = ha.GetHermesName()
 			return ctrl.Result{}, nil
 		}
 		desired.ResourceVersion = cm.ResourceVersion
@@ -43,7 +42,6 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Hermes ConfigMap updated", "namespacedName", nsName)
-		ha.Status.ManagedResources.HermesConfigMap = ha.GetHermesName()
 		return ctrl.Result{}, nil
 	}
 
@@ -53,6 +51,9 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 	}
 	u.tel.Debug(ctx, "Hermes ConfigMap created", "namespacedName", nsName)
 	ha.Status.ManagedResources.HermesConfigMap = ha.GetHermesName()
+	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/usecase/hermesagent_hermes_secret.go
+++ b/internal/usecase/hermesagent_hermes_secret.go
@@ -46,7 +46,8 @@ func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agen
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
-	if existing == nil {
+	created := existing == nil
+	if created {
 		err = u.kube.CreateSecretOwnedByHermesAgent(ctx, CreateSecretOfHermesAgentParam{HermesAgent: ha, Secret: desired})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
@@ -60,7 +61,12 @@ func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agen
 		u.tel.Debug(ctx, "Hermes Secret updated", "namespacedName", nsName)
 	}
 
-	ha.Status.ManagedResources.HermesSecret = ha.GetHermesName()
+	if created {
+		ha.Status.ManagedResources.HermesSecret = ha.GetHermesName()
+		if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+		}
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/usecase/hermesagent_ingress.go
+++ b/internal/usecase/hermesagent_ingress.go
@@ -41,7 +41,6 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 	desired := buildIngress(ha, ing)
 	if existing != nil {
 		if ingressEqual(desired, existing) {
-			ha.Status.ManagedResources.Ingress = ha.Name
 			return ctrl.Result{}, nil
 		}
 		desired.ResourceVersion = existing.ResourceVersion
@@ -50,7 +49,6 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Ingress updated", "namespacedName", nsName)
-		ha.Status.ManagedResources.Ingress = ha.Name
 		return ctrl.Result{}, nil
 	}
 
@@ -60,6 +58,9 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 	}
 	u.tel.Debug(ctx, "Ingress created", "namespacedName", nsName)
 	ha.Status.ManagedResources.Ingress = ha.Name
+	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/usecase/hermesagent_networkpolicy.go
+++ b/internal/usecase/hermesagent_networkpolicy.go
@@ -44,7 +44,6 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 	desired := buildNetworkPolicy(ha, np)
 	if existing != nil {
 		if networkPolicyEqual(desired, existing) {
-			ha.Status.ManagedResources.NetworkPolicy = ha.Name
 			return ctrl.Result{}, nil
 		}
 		desired.ResourceVersion = existing.ResourceVersion
@@ -53,7 +52,6 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "NetworkPolicy updated", "namespacedName", nsName)
-		ha.Status.ManagedResources.NetworkPolicy = ha.Name
 		return ctrl.Result{}, nil
 	}
 
@@ -63,6 +61,9 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 	}
 	u.tel.Debug(ctx, "NetworkPolicy created", "namespacedName", nsName)
 	ha.Status.ManagedResources.NetworkPolicy = ha.Name
+	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/usecase/hermesagent_role.go
+++ b/internal/usecase/hermesagent_role.go
@@ -51,6 +51,7 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		return ctrl.Result{}, nil
 	}
 
+	roleCreated := existingRole == nil
 	desiredRole := buildRole(ha, rules)
 	if existingRole != nil {
 		if !roleEqual(desiredRole, existingRole) {
@@ -69,6 +70,7 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		u.tel.Debug(ctx, "Role created", "namespacedName", nsName)
 	}
 
+	rbCreated := existingRB == nil
 	desiredRB := buildRoleBinding(ha, saName)
 	if existingRB != nil {
 		if !roleBindingEqual(desiredRB, existingRB) {
@@ -87,8 +89,13 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 		u.tel.Debug(ctx, "RoleBinding created", "namespacedName", nsName)
 	}
 
-	ha.Status.ManagedResources.Role = ha.Name
-	ha.Status.ManagedResources.RoleBinding = ha.Name
+	if roleCreated || rbCreated {
+		ha.Status.ManagedResources.Role = ha.Name
+		ha.Status.ManagedResources.RoleBinding = ha.Name
+		if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+		}
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/usecase/hermesagent_searxng_configmap.go
+++ b/internal/usecase/hermesagent_searxng_configmap.go
@@ -39,7 +39,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 	desired := buildSearXNGConfigMap(ha)
 	if existing != nil {
 		if configMapDataEqual(desired, existing) {
-			ha.Status.ManagedResources.SearXNGConfigMap = ha.GetSearXNGName()
 			return ctrl.Result{}, nil
 		}
 		desired.ResourceVersion = existing.ResourceVersion
@@ -48,7 +47,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "SearXNG ConfigMap updated", "namespacedName", nsName)
-		ha.Status.ManagedResources.SearXNGConfigMap = ha.GetSearXNGName()
 		return ctrl.Result{}, nil
 	}
 
@@ -58,6 +56,9 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 	}
 	u.tel.Debug(ctx, "SearXNG ConfigMap created", "namespacedName", nsName)
 	ha.Status.ManagedResources.SearXNGConfigMap = ha.GetSearXNGName()
+	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/usecase/hermesagent_searxng_secret.go
+++ b/internal/usecase/hermesagent_searxng_secret.go
@@ -40,7 +40,6 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 
 	// Never update — preserve the generated secret value across reconciles.
 	if existing != nil {
-		ha.Status.ManagedResources.SearXNGSecret = ha.GetSearXNGName()
 		return ctrl.Result{}, nil
 	}
 
@@ -54,6 +53,9 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 	}
 	u.tel.Debug(ctx, "SearXNG Secret created", "namespacedName", nsName)
 	ha.Status.ManagedResources.SearXNGSecret = ha.GetSearXNGName()
+	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/usecase/hermesagent_service.go
+++ b/internal/usecase/hermesagent_service.go
@@ -42,7 +42,6 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 		// ClusterIP is immutable; carry it over from the existing Service.
 		desired.Spec.ClusterIP = existing.Spec.ClusterIP
 		if serviceEqual(desired, existing) {
-			ha.Status.ManagedResources.Service = ha.Name
 			return ctrl.Result{}, nil
 		}
 		desired.ResourceVersion = existing.ResourceVersion
@@ -51,7 +50,6 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "Service updated", "namespacedName", nsName)
-		ha.Status.ManagedResources.Service = ha.Name
 		return ctrl.Result{}, nil
 	}
 
@@ -61,6 +59,9 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 	}
 	u.tel.Debug(ctx, "Service created", "namespacedName", nsName)
 	ha.Status.ManagedResources.Service = ha.Name
+	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/usecase/hermesagent_serviceaccount.go
+++ b/internal/usecase/hermesagent_serviceaccount.go
@@ -39,7 +39,6 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 	desired := buildServiceAccount(ha)
 	if existing != nil {
 		if serviceAccountEqual(desired, existing) {
-			ha.Status.ManagedResources.ServiceAccount = ha.Name
 			return ctrl.Result{}, nil
 		}
 		desired.ResourceVersion = existing.ResourceVersion
@@ -48,7 +47,6 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
 		u.tel.Debug(ctx, "ServiceAccount updated", "namespacedName", nsName)
-		ha.Status.ManagedResources.ServiceAccount = ha.Name
 		return ctrl.Result{}, nil
 	}
 
@@ -58,6 +56,9 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 	}
 	u.tel.Debug(ctx, "ServiceAccount created", "namespacedName", nsName)
 	ha.Status.ManagedResources.ServiceAccount = ha.Name
+	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+	}
 	return ctrl.Result{}, nil
 }
 

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -58,10 +58,10 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
+		ha.Status.ManagedResources.StatefulSet = ha.Name
 		stsOp = "created"
 	}
 
-	ha.Status.ManagedResources.StatefulSet = ha.Name
 	ha.Status.Phase = u.derivePhase(ctx, ha)
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -48,7 +48,8 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "StatefulSet updated", "namespacedName", nsName, "phase", ha.Status.Phase)
+			// TODO: fix statefulSetSpecEqual to avoid this misleading log when only non-operator-managed fields differ. 
+			// u.tel.Debug(ctx, "StatefulSet updated", "namespacedName", nsName, "phase", ha.Status.Phase)
 		}
 	} else {
 		err = u.kube.CreateStatefulSetOwnedByHermesAgent(ctx, CreateStatefulSetOfHermesAgentParam{HermesAgent: ha, StatefulSet: desired})

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -48,7 +48,7 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			// TODO: fix statefulSetSpecEqual to avoid this misleading log when only non-operator-managed fields differ. 
+			// TODO: fix statefulSetSpecEqual to avoid this misleading log when only non-operator-managed fields differ.
 			// u.tel.Debug(ctx, "StatefulSet updated", "namespacedName", nsName, "phase", ha.Status.Phase)
 		}
 	} else {

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -41,33 +41,30 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 
 	desired := buildStatefulSet(ha)
 
-	var stsOp string
 	if sts != nil {
-		if statefulSetSpecEqual(desired, sts) {
-			return ctrl.Result{}, nil
-		} else {
+		if !statefulSetSpecEqual(desired, sts) {
 			desired.ResourceVersion = sts.ResourceVersion
 			err := u.kube.UpdateStatefulSetOwnedByHermesAgent(ctx, UpdateStatefulSetParam{HermesAgent: ha, StatefulSet: desired})
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			stsOp = "updated"
 		}
+		u.tel.Debug(ctx, "StatefulSet updated", "namespacedName", nsName, "phase", ha.Status.Phase)
 	} else {
 		err = u.kube.CreateStatefulSetOwnedByHermesAgent(ctx, CreateStatefulSetOfHermesAgentParam{HermesAgent: ha, StatefulSet: desired})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		ha.Status.ManagedResources.StatefulSet = ha.Name
-		stsOp = "created"
+		u.tel.Debug(ctx, "StatefulSet created", "namespacedName", nsName, "phase", ha.Status.Phase)
 	}
 
+	ha.Status.ManagedResources.StatefulSet = ha.Name
 	ha.Status.Phase = u.derivePhase(ctx, ha)
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 
-	u.tel.Debug(ctx, "StatefulSet "+stsOp, "namespacedName", nsName, "phase", ha.Status.Phase)
+	// if the StatefulSet is not ready, requeue to check again after a short delay.
 	if ha.Status.Phase == agentsv1alpha1.PhasePending || ha.Status.Phase == agentsv1alpha1.PhaseUnknown {
 		return ctrl.Result{RequeueAfter: 5 * time.Second}, nil
 	}

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -48,8 +48,8 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
+			u.tel.Debug(ctx, "StatefulSet updated", "namespacedName", nsName, "phase", ha.Status.Phase)
 		}
-		u.tel.Debug(ctx, "StatefulSet updated", "namespacedName", nsName, "phase", ha.Status.Phase)
 	} else {
 		err = u.kube.CreateStatefulSetOwnedByHermesAgent(ctx, CreateStatefulSetOfHermesAgentParam{HermesAgent: ha, StatefulSet: desired})
 		if err != nil {


### PR DESCRIPTION
## What changed

Status fields in `ha.Status.ManagedResources` were being set in-memory on the **equal** and **update** paths of every resource reconciler, but `UpdateHermesAgentStatus` (the call that actually persists status to the API server via the status subresource) was only called on **deletion** paths. This made the assignments on equal/update paths no-ops — the status was never actually persisted for those cases.

## Why

The correct semantic is: `ManagedResources.*` tracks the name of each resource being managed. That name only changes when a resource is **first created** (empty → name) or **deleted** (name → empty). An update doesn't change the tracked name, so no status write is needed.

## Changes

Applied consistently across all 10 resource reconcilers:

- **Equal path**: removed the redundant in-memory status assignment (just return early)
- **Update path**: removed the in-memory status assignment (resource is already tracked)
- **Create path**: kept the status assignment and added a `UpdateHermesAgentStatus` call to actually persist it
- **Delete path**: already correct — no changes needed

Special cases:
- `hermesagent_role.go`: tracks `Role` and `RoleBinding` together; added `roleCreated`/`rbCreated` flags and only persists status when at least one was newly created
- `hermesagent_statefulset.go`: `ManagedResources.StatefulSet` moved to the create branch only; `ha.Status.Phase` derivation and `UpdateHermesAgentStatus` remain for both create and update since Phase reflects live pod state
- `hermesagent_hermes_secret.go`: restructured to track `created := existing == nil` and gate the status update on it