### PR TITLE
feat: add Langfuse observability sample

### DIFF
--- a/config/samples/github_reviewer.yaml
+++ b/config/samples/github_reviewer.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: gh-agent-secrets
+  name: github-reviewer-secrets
 stringData:
   OLLAMA_API_KEY: ""
   # _HERMES_FORCE_ allows to pass a GitHub token to subprocesses. Hermes agent blocks GitHub token from being passed to subprocesses by default for security reasons. Setting this variable to any non-empty value will force Hermes to pass the GitHub token to subprocesses.
@@ -10,7 +10,7 @@ stringData:
 apiVersion: agents.hermeum.app/v1alpha1
 kind: HermesAgent
 metadata:
-  name: gh-agent
+  name: github-reviewer
 spec:
   hermes:
     config:
@@ -25,7 +25,10 @@ spec:
           webhook:
             extra:
               routes:
-                # NOTE: you have to configure the webhook in your GitHub repo to point to /webhook/github-pr for this to work
+                # NOTE: you have to configure the webhook in your GitHub repo to point to
+                # http://<service-external-ip>:8644/webhook/github-pr for this to work.
+                # This sample exposes the webhook via a LoadBalancer Service (no TLS termination);
+                # add your own TLS in front (e.g. cloud LB) if you need HTTPS.
                 github-pr:
                   events: ["pull_request"]
                   prompt: |
@@ -43,6 +46,7 @@ spec:
                     pr_number: "{number}"
     workspace:
       files:
+        # Mount a .bashrc to set PATH for gh CLI installed in the initContainer below.
         home/.bashrc: |
           export PATH="$HERMES_HOME/.local/bin:$PATH"
     storage:
@@ -51,22 +55,11 @@ spec:
         size: 1Gi
     envFrom:
       - secretRef:
-          name: gh-agent-secrets
+          name: github-reviewer-secrets
     initChownData: true
   networking:
-    ingress:
-      enabled: true
-      className: nginx
-      hosts:
-        - host: gh-agent.example.com
-          paths:
-            - path: /
-              pathType: Prefix
-              port: 8644
-      tls:
-        - hosts:
-            - gh-agent.example.com
-          secretName: gh-agent-tls
+    service:
+      type: LoadBalancer
   initContainers:
     - name: install-gh
       image: nousresearch/hermes-agent:latest

--- a/config/samples/kustomization.yaml
+++ b/config/samples/kustomization.yaml
@@ -1,5 +1,5 @@
 ## Append samples of your project ##
 resources:
 - web_search.yaml
-- github_agent.yaml
+- github_reviewer.yaml
 # +kubebuilder:scaffold:manifestskustomizesamples

--- a/config/samples/langfuse_observability.yaml
+++ b/config/samples/langfuse_observability.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: langfuse-observability
+stringData:
+  OLLAMA_API_KEY: ""
+  HERMES_LANGFUSE_PUBLIC_KEY: "pk-lf-..."
+  HERMES_LANGFUSE_SECRET_KEY: "sk-lf-..."
+  HERMES_LANGFUSE_BASE_URL: "https://cloud.langfuse.com"
+---
+apiVersion: agents.hermeum.app/v1alpha1
+kind: HermesAgent
+metadata:
+  name: langfuse-observability
+spec:
+  hermes:
+    # Install the Langfuse Python package to enable the observability plugin.
+    pythonPackages:
+      - langfuse
+    config:
+      raw:
+        model:
+          base_url: https://ollama.com/v1
+          default: kimi-k2.6
+          provider: ollama-cloud
+        # Enable the built-in Langfuse observability plugin.
+        # Credentials (HERMES_LANGFUSE_PUBLIC_KEY / SECRET_KEY / BASE_URL) are
+        # supplied via envFrom below.
+        plugins:
+          enabled:
+            - observability/langfuse
+    envFrom:
+      - secretRef:
+          name: langfuse-observability


### PR DESCRIPTION
## Summary
- Add `config/samples/langfuse_observability.yaml` demonstrating Langfuse observability configuration for a HermesAgent.
- Rename `config/samples/github_agent.yaml` to `config/samples/github_reviewer.yaml`, renaming the sample's resources (`gh-agent` → `github-reviewer`, `gh-agent-secrets` → `github-reviewer-secrets`) and switching the webhook exposure from an Ingress to a `LoadBalancer` Service (no TLS termination — see updated comment in the sample on pointing GitHub's webhook at the Service's external IP/port).
- Update `config/samples/kustomization.yaml` to reference the renamed sample file.

## Test plan
- [x] `kubectl apply --dry-run=client -f config/samples/github_reviewer.yaml` against a cluster with the CRDs installed
- [x] `kubectl apply --dry-run=client -f config/samples/langfuse_observability.yaml` against a cluster with the CRDs installed