### PR TITLE
refactor: remove duplicated namespacedName from log messages

### DIFF
--- a/internal/usecase/hermesagent.go
+++ b/internal/usecase/hermesagent.go
@@ -36,16 +36,16 @@ func (u *HermesAgentUseCase) Reconcile(ctx context.Context, param ReconcileParam
 			Seconds:        time.Since(start).Seconds(),
 		})
 	}()
-	u.tel.Info(ctx, "Starting reconciliation", "namespacedName", param.NamespacedName)
+	u.tel.Info(ctx, "Starting reconciliation")
 
 	ha, err := u.kube.GetHermesAgent(ctx, GetHermesAgentParam(param))
 	if err != nil {
-		u.tel.Error(ctx, err, "Failed to get HermesAgent", "namespacedName", param.NamespacedName)
+		u.tel.Error(ctx, err, "Failed to get HermesAgent")
 		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: param.NamespacedName, Result: ResultError})
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	if ha == nil {
-		u.tel.Debug(ctx, "HermesAgent not found", "namespacedName", param.NamespacedName)
+		u.tel.Debug(ctx, "HermesAgent not found")
 		u.tel.IncNotFound(ctx, IncNotFoundParam(param))
 		u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: param.NamespacedName, Result: ResultNotFound})
 		return ctrl.Result{}, nil
@@ -55,76 +55,76 @@ func (u *HermesAgentUseCase) Reconcile(ctx context.Context, param ReconcileParam
 
 	if result, err := u.reconcileHermesConfigMap(ctx, ha); err != nil || !result.IsZero() {
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile Hermes ConfigMap", "namespacedName", nsName)
+			u.tel.Error(ctx, err, "Failed to reconcile Hermes ConfigMap")
 			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		}
 		return result, err
 	}
 	if result, err := u.reconcileHermesSecret(ctx, ha); err != nil || !result.IsZero() {
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile Hermes Secret", "namespacedName", nsName)
+			u.tel.Error(ctx, err, "Failed to reconcile Hermes Secret")
 			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		}
 		return result, err
 	}
 	if result, err := u.reconcileSearXNGConfigMap(ctx, ha); err != nil || !result.IsZero() {
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile SearXNG ConfigMap", "namespacedName", nsName)
+			u.tel.Error(ctx, err, "Failed to reconcile SearXNG ConfigMap")
 			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		}
 		return result, err
 	}
 	if result, err := u.reconcileSearXNGSecret(ctx, ha); err != nil || !result.IsZero() {
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile SearXNG Secret", "namespacedName", nsName)
+			u.tel.Error(ctx, err, "Failed to reconcile SearXNG Secret")
 			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		}
 		return result, err
 	}
 	if result, err := u.reconcileServiceAccount(ctx, ha); err != nil || !result.IsZero() {
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile ServiceAccount", "namespacedName", nsName)
+			u.tel.Error(ctx, err, "Failed to reconcile ServiceAccount")
 			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		}
 		return result, err
 	}
 	if result, err := u.reconcileRole(ctx, ha); err != nil || !result.IsZero() {
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile Role", "namespacedName", nsName)
+			u.tel.Error(ctx, err, "Failed to reconcile Role")
 			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		}
 		return result, err
 	}
 	if result, err := u.reconcileService(ctx, ha); err != nil || !result.IsZero() {
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile Service", "namespacedName", nsName)
+			u.tel.Error(ctx, err, "Failed to reconcile Service")
 			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		}
 		return result, err
 	}
 	if result, err := u.reconcileIngress(ctx, ha); err != nil || !result.IsZero() {
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile Ingress", "namespacedName", nsName)
+			u.tel.Error(ctx, err, "Failed to reconcile Ingress")
 			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		}
 		return result, err
 	}
 	if result, err := u.reconcileNetworkPolicy(ctx, ha); err != nil || !result.IsZero() {
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile NetworkPolicy", "namespacedName", nsName)
+			u.tel.Error(ctx, err, "Failed to reconcile NetworkPolicy")
 			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		}
 		return result, err
 	}
 	if result, err := u.reconcileStatefulSet(ctx, ha); err != nil || !result.IsZero() {
 		if err != nil {
-			u.tel.Error(ctx, err, "Failed to reconcile StatefulSet", "namespacedName", nsName)
+			u.tel.Error(ctx, err, "Failed to reconcile StatefulSet")
 			u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultError})
 		}
 		return result, err
 	}
 
-	u.tel.Info(ctx, "Reconciliation completed successfully", "namespacedName", param.NamespacedName)
+	u.tel.Info(ctx, "Reconciliation completed successfully")
 	u.tel.IncReconcile(ctx, IncReconcileParam{NamespacedName: nsName, Result: ResultSuccess})
 	return ctrl.Result{}, nil
 }

--- a/internal/usecase/hermesagent_hermes_configmap.go
+++ b/internal/usecase/hermesagent_hermes_configmap.go
@@ -17,8 +17,6 @@ import (
 )
 
 func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
-	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
-
 	cmName := ha.GetHermesName()
 	cm, err := u.kube.GetConfigMap(ctx, GetConfigMapParam{
 		NamespacedName: types.NamespacedName{Name: cmName, Namespace: ha.Namespace},
@@ -41,7 +39,7 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "Hermes ConfigMap updated", "namespacedName", nsName)
+		u.tel.Debug(ctx, "Hermes ConfigMap updated")
 		return ctrl.Result{}, nil
 	}
 
@@ -49,7 +47,7 @@ func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *a
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
-	u.tel.Debug(ctx, "Hermes ConfigMap created", "namespacedName", nsName)
+	u.tel.Debug(ctx, "Hermes ConfigMap created")
 	ha.Status.ManagedResources.HermesConfigMap = ha.GetHermesName()
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err

--- a/internal/usecase/hermesagent_hermes_secret.go
+++ b/internal/usecase/hermesagent_hermes_secret.go
@@ -33,7 +33,6 @@ import (
 )
 
 func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
-	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
 	secretNsName := types.NamespacedName{Name: ha.GetHermesName(), Namespace: ha.Namespace}
 
 	existing, err := u.kube.GetSecret(ctx, GetSecretParam{NamespacedName: secretNsName})
@@ -52,13 +51,13 @@ func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agen
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "Hermes Secret created", "namespacedName", nsName)
+		u.tel.Debug(ctx, "Hermes Secret created")
 	} else if !maps.EqualFunc(existing.Data, desired.Data, bytes.Equal) {
 		existing.Data = desired.Data
 		if err := u.kube.UpdateSecretOwnedByHermesAgent(ctx, UpdateSecretOfHermesAgentParam{HermesAgent: ha, Secret: existing}); err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "Hermes Secret updated", "namespacedName", nsName)
+		u.tel.Debug(ctx, "Hermes Secret updated")
 	}
 
 	if created {

--- a/internal/usecase/hermesagent_ingress.go
+++ b/internal/usecase/hermesagent_ingress.go
@@ -29,7 +29,7 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "Ingress deleted", "namespacedName", nsName)
+			u.tel.Debug(ctx, "Ingress deleted")
 		}
 		ha.Status.ManagedResources.Ingress = ""
 		if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
@@ -48,7 +48,7 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "Ingress updated", "namespacedName", nsName)
+		u.tel.Debug(ctx, "Ingress updated")
 		return ctrl.Result{}, nil
 	}
 
@@ -56,7 +56,7 @@ func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1a
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
-	u.tel.Debug(ctx, "Ingress created", "namespacedName", nsName)
+	u.tel.Debug(ctx, "Ingress created")
 	ha.Status.ManagedResources.Ingress = ha.Name
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err

--- a/internal/usecase/hermesagent_networkpolicy.go
+++ b/internal/usecase/hermesagent_networkpolicy.go
@@ -32,7 +32,7 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "NetworkPolicy deleted", "namespacedName", nsName)
+			u.tel.Debug(ctx, "NetworkPolicy deleted")
 		}
 		ha.Status.ManagedResources.NetworkPolicy = ""
 		if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
@@ -51,7 +51,7 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "NetworkPolicy updated", "namespacedName", nsName)
+		u.tel.Debug(ctx, "NetworkPolicy updated")
 		return ctrl.Result{}, nil
 	}
 
@@ -59,7 +59,7 @@ func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *age
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
-	u.tel.Debug(ctx, "NetworkPolicy created", "namespacedName", nsName)
+	u.tel.Debug(ctx, "NetworkPolicy created")
 	ha.Status.ManagedResources.NetworkPolicy = ha.Name
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err

--- a/internal/usecase/hermesagent_role.go
+++ b/internal/usecase/hermesagent_role.go
@@ -34,14 +34,14 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "RoleBinding deleted", "namespacedName", nsName)
+			u.tel.Debug(ctx, "RoleBinding deleted")
 		}
 		if existingRole != nil {
 			err := u.kube.DeleteRole(ctx, DeleteRoleParam{NamespacedName: nsName})
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "Role deleted", "namespacedName", nsName)
+			u.tel.Debug(ctx, "Role deleted")
 		}
 		ha.Status.ManagedResources.Role = ""
 		ha.Status.ManagedResources.RoleBinding = ""
@@ -60,14 +60,14 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "Role updated", "namespacedName", nsName)
+			u.tel.Debug(ctx, "Role updated")
 		}
 	} else {
 		err := u.kube.CreateRoleOwnedByHermesAgent(ctx, CreateRoleOfHermesAgentParam{HermesAgent: ha, Role: desiredRole})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "Role created", "namespacedName", nsName)
+		u.tel.Debug(ctx, "Role created")
 	}
 
 	rbCreated := existingRB == nil
@@ -79,14 +79,14 @@ func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alph
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "RoleBinding updated", "namespacedName", nsName)
+			u.tel.Debug(ctx, "RoleBinding updated")
 		}
 	} else {
 		err := u.kube.CreateRoleBindingOwnedByHermesAgent(ctx, CreateRoleBindingOfHermesAgentParam{HermesAgent: ha, RoleBinding: desiredRB})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "RoleBinding created", "namespacedName", nsName)
+		u.tel.Debug(ctx, "RoleBinding created")
 	}
 
 	if roleCreated || rbCreated {

--- a/internal/usecase/hermesagent_searxng_configmap.go
+++ b/internal/usecase/hermesagent_searxng_configmap.go
@@ -13,7 +13,6 @@ import (
 )
 
 func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
-	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
 	cmNsName := types.NamespacedName{Name: ha.GetSearXNGName(), Namespace: ha.Namespace}
 
 	existing, err := u.kube.GetConfigMap(ctx, GetConfigMapParam{NamespacedName: cmNsName})
@@ -27,7 +26,7 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "SearXNG ConfigMap deleted", "namespacedName", nsName)
+			u.tel.Debug(ctx, "SearXNG ConfigMap deleted")
 		}
 		ha.Status.ManagedResources.SearXNGConfigMap = ""
 		if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
@@ -46,7 +45,7 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "SearXNG ConfigMap updated", "namespacedName", nsName)
+		u.tel.Debug(ctx, "SearXNG ConfigMap updated")
 		return ctrl.Result{}, nil
 	}
 
@@ -54,7 +53,7 @@ func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
-	u.tel.Debug(ctx, "SearXNG ConfigMap created", "namespacedName", nsName)
+	u.tel.Debug(ctx, "SearXNG ConfigMap created")
 	ha.Status.ManagedResources.SearXNGConfigMap = ha.GetSearXNGName()
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err

--- a/internal/usecase/hermesagent_searxng_secret.go
+++ b/internal/usecase/hermesagent_searxng_secret.go
@@ -15,7 +15,6 @@ import (
 )
 
 func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
-	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
 	secretNsName := types.NamespacedName{Name: ha.GetSearXNGName(), Namespace: ha.Namespace}
 
 	existing, err := u.kube.GetSecret(ctx, GetSecretParam{NamespacedName: secretNsName})
@@ -29,7 +28,7 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "SearXNG Secret deleted", "namespacedName", nsName)
+			u.tel.Debug(ctx, "SearXNG Secret deleted")
 		}
 		ha.Status.ManagedResources.SearXNGSecret = ""
 		if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
@@ -51,7 +50,7 @@ func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *age
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
-	u.tel.Debug(ctx, "SearXNG Secret created", "namespacedName", nsName)
+	u.tel.Debug(ctx, "SearXNG Secret created")
 	ha.Status.ManagedResources.SearXNGSecret = ha.GetSearXNGName()
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err

--- a/internal/usecase/hermesagent_service.go
+++ b/internal/usecase/hermesagent_service.go
@@ -29,7 +29,7 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 			if err := u.kube.DeleteService(ctx, DeleteServiceParam{NamespacedName: nsName}); err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "Service deleted (no ports configured)", "namespacedName", nsName)
+			u.tel.Debug(ctx, "Service deleted (no ports configured)")
 		}
 		ha.Status.ManagedResources.Service = ""
 		if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
@@ -49,7 +49,7 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "Service updated", "namespacedName", nsName)
+		u.tel.Debug(ctx, "Service updated")
 		return ctrl.Result{}, nil
 	}
 
@@ -57,7 +57,7 @@ func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1a
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
-	u.tel.Debug(ctx, "Service created", "namespacedName", nsName)
+	u.tel.Debug(ctx, "Service created")
 	ha.Status.ManagedResources.Service = ha.Name
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err

--- a/internal/usecase/hermesagent_serviceaccount.go
+++ b/internal/usecase/hermesagent_serviceaccount.go
@@ -27,7 +27,7 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "ServiceAccount deleted", "namespacedName", nsName)
+			u.tel.Debug(ctx, "ServiceAccount deleted")
 		}
 		ha.Status.ManagedResources.ServiceAccount = ""
 		if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
@@ -46,7 +46,7 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "ServiceAccount updated", "namespacedName", nsName)
+		u.tel.Debug(ctx, "ServiceAccount updated")
 		return ctrl.Result{}, nil
 	}
 
@@ -54,7 +54,7 @@ func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *ag
 	if err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
-	u.tel.Debug(ctx, "ServiceAccount created", "namespacedName", nsName)
+	u.tel.Debug(ctx, "ServiceAccount created")
 	ha.Status.ManagedResources.ServiceAccount = ha.Name
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -58,14 +58,14 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			u.tel.Debug(ctx, "StatefulSet updated", "namespacedName", nsName, "phase", ha.Status.Phase)
+			u.tel.Debug(ctx, "StatefulSet updated", "phase", ha.Status.Phase)
 		}
 	} else {
 		err = u.kube.CreateStatefulSetOwnedByHermesAgent(ctx, CreateStatefulSetOfHermesAgentParam{HermesAgent: ha, StatefulSet: desired})
 		if err != nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 		}
-		u.tel.Debug(ctx, "StatefulSet created", "namespacedName", nsName, "phase", ha.Status.Phase)
+		u.tel.Debug(ctx, "StatefulSet created", "phase", ha.Status.Phase)
 	}
 
 	ha.Status.ManagedResources.StatefulSet = ha.Name
@@ -76,7 +76,7 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 
 	// if the StatefulSet is not ready, requeue to check again after a short delay.
 	if ha.Status.Phase == agentsv1alpha1.PhasePending || ha.Status.Phase == agentsv1alpha1.PhaseUnknown {
-		u.tel.Debug(ctx, "StatefulSet not ready", "namespacedName", nsName, "phase", ha.Status.Phase)
+		u.tel.Debug(ctx, "StatefulSet not ready", "phase", ha.Status.Phase)
 		return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 	}
 	return ctrl.Result{}, nil


### PR DESCRIPTION
## Summary

- `controller-runtime` already injects `name` and `namespace` into the context logger at the start of each reconcile loop via `log.FromContext(ctx)`, so passing `"namespacedName", nsName` as an explicit key-value pair on every `tel.Debug`/`Info`/`Error` call was redundant.
- Removed the `"namespacedName"` key-value from all log calls across 11 usecase files.
- For files where `nsName` was only referenced in log calls (`hermesagent_hermes_configmap.go`, `hermesagent_searxng_configmap.go`, `hermesagent_searxng_secret.go`, `hermesagent_hermes_secret.go`), the unused variable declaration was also removed.

## Test plan

- [x] `make lint` passes (verified: 0 issues)
- [x] Existing unit/integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)