### PR TITLE
docs: add Examples section pointing to config/samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ kubectl get hermesagent my-agent
 kubectl get pods -l app.kubernetes.io/instance=my-agent
 ```
 
+## Examples
+
+Ready-to-apply manifests live in [`config/samples/`](./config/samples/). Each file includes a Secret for credentials and a `HermesAgent` resource. Fill in the Secret values, then apply:
+
+```sh
+kubectl apply -f config/samples/web_search.yaml
+```
+
 ## Configuration
 
 - [`hermes.config`](#hermesconfig)


### PR DESCRIPTION
## Summary

- Adds an **Examples** section to `README.md` between Quick Start and Configuration
- Points users to `config/samples/` with a brief description and a one-liner to apply a sample

## Reviewer notes

The section is intentionally minimal — just a directory pointer and a usage snippet — per the author's preference not to enumerate individual sample files inline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)