### PR TITLE
feat: harden team installs and add smoke test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= ghcr.io/hermeum/hermes-agent-operator:latest
+IMG ?= ghcr.io/hermeum/hermes-agent-operator:0.5.0
 # YEAR defines the year value used for substituting the YEAR placeholder in the boilerplate header.
 YEAR ?= $(shell date +%Y)
 
@@ -292,6 +292,10 @@ helm-deploy: install-helm ## Deploy manager to the K8s cluster via Helm. Specify
 		--wait \
 		--timeout 5m \
 		$(HELM_EXTRA_ARGS)
+
+.PHONY: smoke
+smoke: ## Run bounded Kubernetes smoke test against deployed operator (set HELM_INSTALL=true to install first).
+	NS=$(HELM_NAMESPACE) HELM=$(HELM) HELM_RELEASE=$(HELM_RELEASE) HELM_CHART=$(HELM_CHART_DIR) HELM_ARGS='$(HELM_EXTRA_ARGS)' hack/smoke.sh
 
 .PHONY: helm-uninstall
 helm-uninstall: ## Uninstall the Helm release from the K8s cluster.

--- a/README.md
+++ b/README.md
@@ -16,9 +16,42 @@ Hermes agent is a powerful tool for automating tasks — but it is designed for 
 
 ### 1. Install the operator
 
+Cluster-wide/admin install (installs or upgrades the CRD and watches all namespaces):
+
 ```sh
 helm upgrade hermes-agent-operator oci://ghcr.io/hermeum/charts/hermes-agent-operator \
-  --install --namespace hermes-agent --create-namespace
+  --install --namespace hermes-agent --create-namespace \
+  --version 0.3.0 \
+  --set manager.image.tag=0.5.0
+```
+
+Namespace-scoped/team install (requires a platform admin to install or upgrade the CRD first):
+
+```sh
+helm upgrade hermes-agent-operator oci://ghcr.io/hermeum/charts/hermes-agent-operator \
+  --install --namespace team-a-hermes --create-namespace \
+  --version 0.3.0 \
+  -f dist/chart/values-team.yaml \
+  --set manager.image.tag=0.5.0
+```
+
+In namespace-scoped mode the operator is granted only a namespaced Role/RoleBinding and watches only the release namespace. Secure metrics authentication requires cluster-scoped TokenReview/SubjectAccessReview RBAC, so `values-team.yaml` disables secure metrics.
+
+#### Orgo+k3s Kubernetes API connectivity
+
+Some Orgo+k3s clusters do not allow Pods to reach the Kubernetes API through `kubernetes.default.svc`, while the node-local k3s API is reachable at `127.0.0.1:6443`. If the manager logs Kubernetes API connection errors or `HermesAgent` resources remain unreconciled, install with host networking and explicit API environment variables:
+
+```sh
+helm upgrade hermes-agent-operator oci://ghcr.io/hermeum/charts/hermes-agent-operator \
+  --install --namespace hermes-agent --create-namespace \
+  --version 0.3.0 \
+  --set manager.hostNetwork=true \
+  --set manager.dnsPolicy=ClusterFirstWithHostNet \
+  --set manager.env[0].name=KUBERNETES_SERVICE_HOST \
+  --set-string manager.env[0].value=127.0.0.1 \
+  --set manager.env[1].name=KUBERNETES_SERVICE_PORT \
+  --set-string manager.env[1].value=6443 \
+  --wait --timeout 5m
 ```
 
 ### 2. Create a secret with your API key
@@ -55,6 +88,39 @@ EOF
 kubectl get hermesagent my-agent
 kubectl get pods -l app.kubernetes.io/instance=my-agent
 ```
+
+### 4. Smoke test the operator and a HermesAgent
+
+Run the bundled, timeout-bounded smoke test against an already installed operator:
+
+```sh
+make smoke
+# or: NS=hermes-agent hack/smoke.sh
+```
+
+The smoke is namespace-aware (`NS`, or `HELM_NAMESPACE` through `make smoke`) and verifies operator rollout, `HermesAgent` apply/reconciliation, generated StatefulSet rollout, agent Pod `Running`/`Ready`, and the agent API `/health` endpoint via `kubectl port-forward`. By default it cleans up the smoke `HermesAgent` and Secret on exit; set `CLEANUP=false` to inspect resources after the run.
+
+To have the script install/upgrade the chart first, run:
+
+```sh
+HELM_INSTALL=true make smoke
+```
+
+To additionally ask the agent a prompt, provide model credentials/config. The answer check is optional and runs automatically when `ANTHROPIC_API_KEY` or `OPENAI_API_KEY` is present:
+
+```sh
+ANTHROPIC_API_KEY=sk-ant-... RUN_AGENT_QUERY=true make smoke
+```
+
+Useful overrides include `AGENT`, `OPERATOR_DEPLOYMENT`, `MODEL_PROVIDER`, `MODEL_DEFAULT`, `API_PORT`, `LOCAL_PORT`, `ROLLOUT_TIMEOUT`, and `AGENT_TIMEOUT`.
+
+## Upgrades
+
+For production and team installations, pin both the chart and controller image, for example `--version 0.3.0 --set manager.image.tag=0.5.0` or `--set manager.image.digest=sha256:...`. Do not rely on mutable `latest` tags.
+
+CRDs are cluster-scoped. In team mode, a platform admin should apply CRD upgrades first, then teams upgrade their namespace-scoped release with `crd.enable=false` (or `dist/chart/values-team.yaml`). Helm rollback does not safely downgrade CRD schemas; validate rollback plans against existing `HermesAgent` objects before changing CRDs in production.
+
+For namespace-scoped installs, External Secrets integration, Orgo/k3s API connectivity, and admission guardrails, see [`docs/team-install.md`](./docs/team-install.md).
 
 ## Examples
 
@@ -129,6 +195,52 @@ hermes:
         name: my-webhook-secret    # name of the Secret in the same namespace
         key: WEBHOOK_SECRET        # key within that Secret
 ```
+
+#### External Secrets integration
+
+The operator consumes ordinary Kubernetes Secrets through `hermes.envFrom`, `apiServer.existingSecret`, and `webhook.secretRef`, so it works with External Secrets Operator, Vault Secrets Operator, or any controller that materializes a Secret in the same namespace as the `HermesAgent`. Install the secret sync controller separately, then reference the resulting Secret:
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: my-hermes-secret
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: team-secret-store
+    kind: SecretStore
+  target:
+    name: my-hermes-secret
+  data:
+    - secretKey: ANTHROPIC_API_KEY
+      remoteRef:
+        key: /teams/team-a/anthropic-api-key
+---
+apiVersion: agents.hermeum.app/v1alpha1
+kind: HermesAgent
+metadata:
+  name: my-agent
+spec:
+  hermes:
+    envFrom:
+      - secretRef:
+          name: my-hermes-secret
+```
+
+Create the `ExternalSecret` before the `HermesAgent` where possible. If the Secret is delayed, Kubernetes will keep the agent Pod pending or restarting until the key appears. Do not commit literal provider API keys in sample manifests or GitOps repositories.
+
+#### Team-install guardrails
+
+A `HermesAgent` can influence Pod containers, volumes, Services, Ingresses, NetworkPolicies, and optional namespaced RBAC. Treat write access to `HermesAgent` as the ability to run code in that namespace. For shared team clusters:
+
+- prefer `dist/chart/values-team.yaml` (`crd.enable=false`, `rbac.namespaced=true`, `metrics.secure=false`);
+- keep CRD installation and upgrades platform-admin owned;
+- pin chart versions and image tags or digests;
+- avoid `networking.service.type: LoadBalancer`/`NodePort` and public Ingress unless reviewed;
+- review `spec.security.rbac.additionalRules` because it can grant the agent ServiceAccount additional namespace permissions;
+- avoid arbitrary `sidecars`, `initContainers`, and `extraVolumes` unless the namespace owner explicitly allows them;
+- use cluster admission policy (Kyverno/Gatekeeper/CEL ValidatingAdmissionPolicy) to block hostPath volumes, privileged containers, wildcard RBAC rules, public exposure, and missing NetworkPolicies for externally exposed agents.
 
 ### `hermes.storage`
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -29,6 +29,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/filters"
@@ -62,6 +63,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var watchNamespace string
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -80,6 +82,8 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.StringVar(&watchNamespace, "watch-namespace", os.Getenv("WATCH_NAMESPACE"),
+		"Namespace to watch for HermesAgent resources. Leave empty to watch all namespaces.")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -155,7 +159,7 @@ func main() {
 		metricsServerOptions.KeyName = metricsCertKey
 	}
 
-	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
+	managerOptions := ctrl.Options{
 		Scheme:                 scheme,
 		Metrics:                metricsServerOptions,
 		WebhookServer:          webhookServer,
@@ -173,7 +177,17 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
-	})
+	}
+
+	if watchNamespace != "" {
+		setupLog.Info("Restricting manager cache to namespace", "namespace", watchNamespace)
+		managerOptions.Cache.DefaultNamespaces = map[string]cache.Config{
+			watchNamespace: {},
+		}
+		managerOptions.LeaderElectionNamespace = watchNamespace
+	}
+
+	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), managerOptions)
 	if err != nil {
 		setupLog.Error(err, "Failed to start manager")
 		os.Exit(1)

--- a/dist/chart/templates/_helpers.tpl
+++ b/dist/chart/templates/_helpers.tpl
@@ -32,6 +32,14 @@ Always uses the Helm release namespace.
 {{- end }}
 
 {{/*
+Namespace the manager watches in namespaced mode.
+Defaults to the Helm release namespace for least-privilege team installs.
+*/}}
+{{- define "hermes-agent-operator.watchNamespace" -}}
+{{- .Values.manager.watchNamespace | default .Release.Namespace }}
+{{- end }}
+
+{{/*
 Resource name with proper truncation for Kubernetes 63-character limit.
 Takes a dict with:
   - .suffix: Resource name suffix (e.g., "metrics", "webhook")

--- a/dist/chart/templates/manager/manager.yaml
+++ b/dist/chart/templates/manager/manager.yaml
@@ -53,6 +53,14 @@ spec:
         {{- end }}
         {{- end }}
     spec:
+      {{- if .Values.manager.hostNetwork }}
+      hostNetwork: true
+      {{- end }}
+      {{- if .Values.manager.dnsPolicy }}
+      dnsPolicy: {{ .Values.manager.dnsPolicy | quote }}
+      {{- else if .Values.manager.hostNetwork }}
+      dnsPolicy: ClusterFirstWithHostNet
+      {{- end }}
       {{- with .Values.manager.topologySpreadConstraints }}
       topologySpreadConstraints: {{ toYaml . | nindent 10 }}
       {{- end }}
@@ -84,12 +92,17 @@ spec:
         - --metrics-bind-address=0
         {{- end }}
         - --health-probe-bind-address=:8081
+        {{- if .Values.rbac.namespaced }}
+        - --watch-namespace={{ include "hermes-agent-operator.watchNamespace" . }}
+        {{- else if .Values.manager.watchNamespace }}
+        - --watch-namespace={{ .Values.manager.watchNamespace }}
+        {{- end }}
         {{- range .Values.manager.args }}
         - {{ . }}
         {{- end }}
         command:
         - /manager
-        image: "{{ .Values.manager.image.repository }}{{- if not (contains "@" .Values.manager.image.repository) }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}{{- end }}"
+        image: "{{ .Values.manager.image.repository }}{{- if .Values.manager.image.digest }}@{{ .Values.manager.image.digest }}{{- else if not (contains "@" .Values.manager.image.repository) }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}{{- end }}"
         {{- with .Values.manager.image.pullPolicy }}
         imagePullPolicy: {{ . }}
         {{- end }}
@@ -122,6 +135,10 @@ spec:
           {{- else }}
           {}
           {{- end }}
+        {{- with .Values.manager.env }}
+        env:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
         volumeMounts:
           {{- if .Values.manager.extraVolumeMounts }}
           {{- toYaml .Values.manager.extraVolumeMounts | nindent 10 }}

--- a/dist/chart/templates/rbac/leader-election-role.yaml
+++ b/dist/chart/templates/rbac/leader-election-role.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ include "hermes-agent-operator.resourceName" (dict "suffix" "leader-election-role" "context" $) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "hermes-agent-operator.watchNamespace" . }}
 rules:
 - apiGroups:
   - ""

--- a/dist/chart/templates/rbac/leader-election-rolebinding.yaml
+++ b/dist/chart/templates/rbac/leader-election-rolebinding.yaml
@@ -7,7 +7,7 @@ metadata:
     helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   name: {{ include "hermes-agent-operator.resourceName" (dict "suffix" "leader-election-rolebinding" "context" $) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "hermes-agent-operator.watchNamespace" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/dist/chart/templates/rbac/manager-role.yaml
+++ b/dist/chart/templates/rbac/manager-role.yaml
@@ -6,7 +6,7 @@ kind: ClusterRole
 {{- end }}
 metadata:
 {{- if .Values.rbac.namespaced }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "hermes-agent-operator.watchNamespace" . }}
 {{- end }}
   name: {{ include "hermes-agent-operator.resourceName" (dict "suffix" "manager-role" "context" $) }}
 rules:

--- a/dist/chart/templates/rbac/manager-rolebinding.yaml
+++ b/dist/chart/templates/rbac/manager-rolebinding.yaml
@@ -6,7 +6,7 @@ kind: ClusterRoleBinding
 {{- end }}
 metadata:
 {{- if .Values.rbac.namespaced }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "hermes-agent-operator.watchNamespace" . }}
 {{- end }}
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/dist/chart/templates/validate.yaml
+++ b/dist/chart/templates/validate.yaml
@@ -1,0 +1,3 @@
+{{- if and .Values.rbac.namespaced .Values.metrics.enable .Values.metrics.secure }}
+{{- fail "metrics.secure=true requires cluster-scoped RBAC for TokenReview/SubjectAccessReview; set metrics.secure=false for rbac.namespaced=true team installs" }}
+{{- end }}

--- a/dist/chart/values-orgo-k3s.yaml
+++ b/dist/chart/values-orgo-k3s.yaml
@@ -1,0 +1,13 @@
+# Orgo/k3s install overlay for clusters where Pods cannot reach the
+# Kubernetes API service IP (kubernetes.default.svc / 10.43.0.1), but the
+# node-local k3s API is reachable from host networking.
+manager:
+  hostNetwork: true
+  # Defaults to ClusterFirstWithHostNet when hostNetwork=true; keep explicit
+  # here so the rendered pod spec is stable for team installs.
+  dnsPolicy: ClusterFirstWithHostNet
+  env:
+    - name: KUBERNETES_SERVICE_HOST
+      value: "127.0.0.1"
+    - name: KUBERNETES_SERVICE_PORT
+      value: "6443"

--- a/dist/chart/values-team.yaml
+++ b/dist/chart/values-team.yaml
@@ -1,0 +1,13 @@
+# Team/namespace-scoped install defaults.
+# Platform admins must install/upgrade CRDs separately before applying this file.
+crd:
+  enable: false
+
+rbac:
+  namespaced: true
+  helpers:
+    enable: false
+
+metrics:
+  # Secure metrics require cluster-scoped TokenReview/SubjectAccessReview RBAC.
+  secure: false

--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -17,10 +17,37 @@ manager:
 
   image:
     repository: ghcr.io/hermeum/hermes-agent-operator
-    ## Image tag (defaults to Chart.appVersion if not set)
+    ## Image tag (defaults to Chart.appVersion if not set). Avoid mutable tags for team installs.
     ##
-    # tag: "latest"
+    tag: "0.5.0"
+    ## Optional immutable digest. When set, the chart renders repository@digest and ignores tag.
+    ## Example: sha256:...
+    ##
+    digest: ""
     pullPolicy: IfNotPresent
+
+  ## Namespace watched by the controller. Empty means all namespaces.
+  ## When rbac.namespaced=true, the chart defaults this to the release namespace.
+  ##
+  watchNamespace: ""
+
+  ## Run the manager in the node network namespace. This is normally false, but
+  ## can be required on Orgo+k3s clusters where Pods cannot reach the Kubernetes
+  ## API through kubernetes.default.svc while the node-local k3s API is reachable.
+  ##
+  hostNetwork: false
+
+  ## Pod DNS policy. Defaults to ClusterFirstWithHostNet when hostNetwork=true.
+  ##
+  dnsPolicy: ""
+
+  ## Extra environment variables for the manager container. For Orgo+k3s, set:
+  ## - name: KUBERNETES_SERVICE_HOST
+  ##   value: "127.0.0.1"
+  ## - name: KUBERNETES_SERVICE_PORT
+  ##   value: "6443"
+  ##
+  env: []
 
   ## Arguments
   ##

--- a/docs/admission/hermesagent-team-guardrails.yaml
+++ b/docs/admission/hermesagent-team-guardrails.yaml
@@ -1,0 +1,50 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: hermesagent-team-guardrails
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+      - apiGroups: ["agents.hermeum.app"]
+        apiVersions: ["v1alpha1"]
+        operations: ["CREATE", "UPDATE"]
+        resources: ["hermesagents"]
+  validations:
+    - expression: "!has(object.spec.extraVolumes) || object.spec.extraVolumes.all(v, !has(v.hostPath))"
+      message: "HermesAgent spec.extraVolumes must not use hostPath volumes"
+    - expression: "!has(object.spec.sidecars) || object.spec.sidecars.all(c, !has(c.securityContext) || !has(c.securityContext.privileged) || c.securityContext.privileged != true)"
+      message: "HermesAgent sidecars must not set securityContext.privileged=true"
+    - expression: "!has(object.spec.initContainers) || object.spec.initContainers.all(c, !has(c.securityContext) || !has(c.securityContext.privileged) || c.securityContext.privileged != true)"
+      message: "HermesAgent initContainers must not set securityContext.privileged=true"
+    - expression: "!has(object.spec.sidecars) || object.spec.sidecars.all(c, !has(c.securityContext) || !has(c.securityContext.allowPrivilegeEscalation) || c.securityContext.allowPrivilegeEscalation != true)"
+      message: "HermesAgent sidecars must not set allowPrivilegeEscalation=true"
+    - expression: "!has(object.spec.initContainers) || object.spec.initContainers.all(c, !has(c.securityContext) || !has(c.securityContext.allowPrivilegeEscalation) || c.securityContext.allowPrivilegeEscalation != true)"
+      message: "HermesAgent initContainers must not set allowPrivilegeEscalation=true"
+    - expression: "!has(object.spec.sidecars) || size(object.spec.sidecars) == 0 || (has(object.metadata.labels) && 'hermeum.app/allow-custom-containers' in object.metadata.labels && object.metadata.labels['hermeum.app/allow-custom-containers'] == 'true')"
+      message: "HermesAgent sidecars require review label hermeum.app/allow-custom-containers=true"
+    - expression: "!has(object.spec.initContainers) || size(object.spec.initContainers) == 0 || (has(object.metadata.labels) && 'hermeum.app/allow-custom-containers' in object.metadata.labels && object.metadata.labels['hermeum.app/allow-custom-containers'] == 'true')"
+      message: "HermesAgent initContainers require review label hermeum.app/allow-custom-containers=true"
+    - expression: "!has(object.spec.networking) || !has(object.spec.networking.service) || !has(object.spec.networking.service.type) || object.spec.networking.service.type == '' || object.spec.networking.service.type == 'ClusterIP' || (has(object.metadata.labels) && 'hermeum.app/allow-public-exposure' in object.metadata.labels && object.metadata.labels['hermeum.app/allow-public-exposure'] == 'true')"
+      message: "HermesAgent LoadBalancer/NodePort Services require review label hermeum.app/allow-public-exposure=true"
+    - expression: "!has(object.spec.networking) || !has(object.spec.networking.ingress) || !has(object.spec.networking.ingress.enabled) || object.spec.networking.ingress.enabled != true || (has(object.metadata.labels) && 'hermeum.app/allow-public-exposure' in object.metadata.labels && object.metadata.labels['hermeum.app/allow-public-exposure'] == 'true')"
+      message: "HermesAgent Ingress requires review label hermeum.app/allow-public-exposure=true"
+    - expression: "!has(object.spec.security) || !has(object.spec.security.rbac) || !has(object.spec.security.rbac.additionalRules) || object.spec.security.rbac.additionalRules.all(r, !('*' in r.apiGroups) && !('*' in r.resources) && !('*' in r.verbs))"
+      message: "HermesAgent spec.security.rbac.additionalRules must not contain wildcard apiGroups, resources, or verbs"
+    - expression: "!(has(object.spec.networking) && has(object.spec.networking.ingress) && has(object.spec.networking.ingress.enabled) && object.spec.networking.ingress.enabled == true) || (has(object.spec.security) && has(object.spec.security.networkPolicy) && (!has(object.spec.security.networkPolicy.enabled) || object.spec.security.networkPolicy.enabled == true))"
+      message: "Externally exposed HermesAgent Ingress requires spec.security.networkPolicy enabled"
+    - expression: "!(has(object.spec.networking) && has(object.spec.networking.service) && has(object.spec.networking.service.type) && object.spec.networking.service.type in ['LoadBalancer', 'NodePort']) || (has(object.spec.security) && has(object.spec.security.networkPolicy) && (!has(object.spec.security.networkPolicy.enabled) || object.spec.security.networkPolicy.enabled == true))"
+      message: "Externally exposed HermesAgent Service requires spec.security.networkPolicy enabled"
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: hermesagent-team-guardrails
+spec:
+  policyName: hermesagent-team-guardrails
+  validationActions: [Deny]
+  # Uncomment to limit enforcement to namespaces explicitly enrolled by the platform team.
+  # matchResources:
+  #   namespaceSelector:
+  #     matchLabels:
+  #       hermeum.app/hermesagent-guardrails: "enabled"

--- a/docs/team-install.md
+++ b/docs/team-install.md
@@ -1,0 +1,236 @@
+# Team installation guide
+
+This guide covers namespace-scoped `hermes-agent-operator` installs for shared clusters.
+It assumes a platform/admin team owns cluster-scoped resources such as CRDs and admission
+policies, while each application team owns a namespace-scoped Helm release.
+
+## Install model
+
+1. Platform admin installs or upgrades the `HermesAgent` CRD once per cluster.
+2. Team installs the operator in its namespace with namespaced RBAC.
+3. Team creates `HermesAgent` objects and same-namespace Secrets.
+
+```sh
+# Platform/admin step: install or update cluster-scoped CRDs.
+helm template hermes-agent-operator oci://ghcr.io/hermeum/charts/hermes-agent-operator \
+  --version 0.3.0 \
+  --set manager.enabled=false \
+  --set crd.enable=true \
+| kubectl apply -f -
+
+# Team step: namespaced operator install; does not manage CRDs.
+helm upgrade hermes-agent-operator oci://ghcr.io/hermeum/charts/hermes-agent-operator \
+  --install --namespace team-a-hermes --create-namespace \
+  --version 0.3.0 \
+  -f dist/chart/values-team.yaml \
+  --set manager.image.tag=0.5.0 \
+  --wait --timeout 5m
+```
+
+`dist/chart/values-team.yaml` sets:
+
+```yaml
+crd:
+  enable: false
+rbac:
+  namespaced: true
+metrics:
+  secure: false
+```
+
+Secure controller-runtime metrics require cluster-scoped TokenReview and
+SubjectAccessReview permissions, so team installs either disable secure metrics or use a
+platform-owned cluster-wide release.
+
+## Orgo/k3s API connectivity
+
+Some Orgo+k3s clusters cannot route from Pods to `https://kubernetes.default.svc`, even
+though the node-local k3s API is reachable on `127.0.0.1:6443`. Symptoms include manager
+logs with Kubernetes API connection failures and `HermesAgent` objects that never
+reconcile.
+
+Workaround: run the manager with host networking and point the in-cluster client at the
+node-local API endpoint.
+
+```sh
+helm upgrade hermes-agent-operator oci://ghcr.io/hermeum/charts/hermes-agent-operator \
+  --install --namespace team-a-hermes --create-namespace \
+  --version 0.3.0 \
+  -f dist/chart/values-team.yaml \
+  --set manager.image.tag=0.5.0 \
+  --set manager.hostNetwork=true \
+  --set manager.dnsPolicy=ClusterFirstWithHostNet \
+  --set manager.env[0].name=KUBERNETES_SERVICE_HOST \
+  --set-string manager.env[0].value=127.0.0.1 \
+  --set manager.env[1].name=KUBERNETES_SERVICE_PORT \
+  --set-string manager.env[1].value=6443 \
+  --wait --timeout 5m
+```
+
+Prefer fixing cluster DNS/service routing when possible. Use host networking only for the
+operator manager Pod, not for agent Pods.
+
+## Pin images and upgrades
+
+For production/team installs, pin both the chart and images. Do not rely on `latest`.
+
+```sh
+helm upgrade hermes-agent-operator oci://ghcr.io/hermeum/charts/hermes-agent-operator \
+  --install --namespace team-a-hermes \
+  --version 0.3.0 \
+  -f dist/chart/values-team.yaml \
+  --set manager.image.tag=0.5.0
+```
+
+For stronger immutability, pin by digest:
+
+```sh
+helm upgrade hermes-agent-operator oci://ghcr.io/hermeum/charts/hermes-agent-operator \
+  --install --namespace team-a-hermes \
+  --version 0.3.0 \
+  -f dist/chart/values-team.yaml \
+  --set manager.image.digest=sha256:<controller-image-digest>
+```
+
+Recommended upgrade path:
+
+1. Read release notes and CRD schema changes.
+2. Platform admin applies CRDs first.
+3. Teams upgrade namespace-scoped releases with `crd.enable=false`.
+4. Verify manager rollout and one canary `HermesAgent` before broad rollout.
+5. Rollbacks can safely roll back the controller image/chart templates, but do not assume
+   Helm can downgrade CRD schemas. Validate CRD rollback plans against existing objects.
+
+Agent runtime images can also be pinned per `HermesAgent`:
+
+```yaml
+apiVersion: agents.hermeum.app/v1alpha1
+kind: HermesAgent
+metadata:
+  name: my-agent
+spec:
+  hermes:
+    image:
+      repository: nousresearch/hermes-agent
+      tag: "<pinned-version>"
+```
+
+## External Secrets integration
+
+The operator does not need direct access to Vault, cloud secret managers, or External
+Secrets APIs. It reads ordinary Kubernetes Secrets referenced from the `HermesAgent` in
+the same namespace. Any controller that materializes a Kubernetes Secret works, including
+External Secrets Operator and Vault Secrets Operator.
+
+Create the `ExternalSecret` before the `HermesAgent` when possible. If the target Secret
+is delayed, Kubernetes may keep the agent Pod pending or restarting until the Secret key
+exists.
+
+```yaml
+apiVersion: external-secrets.io/v1
+kind: SecretStore
+metadata:
+  name: team-secret-store
+  namespace: team-a-hermes
+spec:
+  provider:
+    # Example only; configure the provider/auth for your environment.
+    vault:
+      server: https://vault.example.com
+      path: secret
+      version: v2
+      auth:
+        kubernetes:
+          mountPath: kubernetes
+          role: team-a-hermes
+          serviceAccountRef:
+            name: external-secrets
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: my-hermes-secret
+  namespace: team-a-hermes
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: team-secret-store
+    kind: SecretStore
+  target:
+    name: my-hermes-secret
+    creationPolicy: Owner
+  data:
+    - secretKey: ANTHROPIC_API_KEY
+      remoteRef:
+        key: teams/team-a/hermes
+        property: anthropic_api_key
+    - secretKey: API_SERVER_KEY
+      remoteRef:
+        key: teams/team-a/hermes
+        property: api_server_key
+    - secretKey: WEBHOOK_SECRET
+      remoteRef:
+        key: teams/team-a/hermes
+        property: webhook_secret
+---
+apiVersion: agents.hermeum.app/v1alpha1
+kind: HermesAgent
+metadata:
+  name: my-agent
+  namespace: team-a-hermes
+spec:
+  hermes:
+    config:
+      raw:
+        model:
+          provider: anthropic
+          default: claude-sonnet-4-6
+      apiServer:
+        enabled: true
+        existingSecret:
+          name: my-hermes-secret
+          key: API_SERVER_KEY
+      webhook:
+        enabled: true
+        secretRef:
+          name: my-hermes-secret
+          key: WEBHOOK_SECRET
+    envFrom:
+      - secretRef:
+          name: my-hermes-secret
+```
+
+Do not commit literal provider API keys to GitOps repositories. Commit only references to
+external secret paths and keep access to those paths scoped to the team namespace.
+
+## Admission guardrails
+
+A `HermesAgent` can run code and influence Pods, volumes, Services, Ingresses,
+NetworkPolicies, and optional namespaced RBAC. Treat write access to `HermesAgent` as the
+ability to run code in that namespace.
+
+For shared clusters, install admission policy that blocks unsafe specs by default and
+requires an explicit review label for exceptions. A concrete Kubernetes
+`ValidatingAdmissionPolicy` example lives in:
+
+- [`docs/admission/hermesagent-team-guardrails.yaml`](./admission/hermesagent-team-guardrails.yaml)
+
+The example blocks:
+
+- `hostPath` volumes;
+- privileged containers and `allowPrivilegeEscalation: true` in user-supplied sidecars or
+  init containers;
+- user-supplied `sidecars` or `initContainers` unless labeled
+  `hermeum.app/allow-custom-containers: "true"`;
+- `LoadBalancer`/`NodePort` Services and enabled Ingress unless labeled
+  `hermeum.app/allow-public-exposure: "true"`;
+- wildcard `spec.security.rbac.additionalRules`;
+- externally exposed agents without an enabled `spec.security.networkPolicy`.
+
+Apply it as a platform/admin step after the CRD exists:
+
+```sh
+kubectl apply -f docs/admission/hermesagent-team-guardrails.yaml
+```
+
+Adjust labels and allowed patterns to match your cluster's approval workflow.

--- a/hack/smoke.sh
+++ b/hack/smoke.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# Smoke test for a deployed hermes-agent-operator.
+#
+# Checks, with bounded waits:
+#   1. optional Helm install/upgrade of the operator
+#   2. operator Deployment rollout in the target namespace
+#   3. HermesAgent CR apply/reconciliation
+#   4. generated StatefulSet rollout and agent Pod Ready/Running
+#   5. optional API health/query when API credentials are supplied
+#
+# Common usage:
+#   NS=hermes-agent hack/smoke.sh
+#   ANTHROPIC_API_KEY=... RUN_AGENT_QUERY=true hack/smoke.sh
+#   HELM_INSTALL=true HELM_RELEASE=hermes-agent-operator hack/smoke.sh
+
+NS="${NS:-hermes-agent}"
+AGENT="${AGENT:-hermes-smoke}"
+KUBECTL="${KUBECTL:-kubectl}"
+HELM="${HELM:-helm}"
+HELM_INSTALL="${HELM_INSTALL:-false}"
+HELM_RELEASE="${HELM_RELEASE:-hermes-agent-operator}"
+HELM_CHART="${HELM_CHART:-dist/chart}"
+HELM_ARGS="${HELM_ARGS:-}"
+OPERATOR_DEPLOYMENT="${OPERATOR_DEPLOYMENT:-}"
+MODEL_PROVIDER="${MODEL_PROVIDER:-anthropic}"
+MODEL_DEFAULT="${MODEL_DEFAULT:-claude-sonnet-4-5}"
+API_PORT="${API_PORT:-8642}"
+LOCAL_PORT="${LOCAL_PORT:-18642}"
+PROMPT="${PROMPT:-Reply with exactly: smoke-ok}"
+EXPECTED_SUBSTRING="${EXPECTED_SUBSTRING:-smoke-ok}"
+RUN_AGENT_QUERY="${RUN_AGENT_QUERY:-auto}"
+CLEANUP="${CLEANUP:-true}"
+ROLLOUT_TIMEOUT="${ROLLOUT_TIMEOUT:-180s}"
+AGENT_TIMEOUT="${AGENT_TIMEOUT:-300s}"
+CURL_MAX_TIME="${CURL_MAX_TIME:-10}"
+
+created_secret=false
+pf_pid=""
+tmp_env=""
+
+log() { printf '==> %s\n' "$*"; }
+warn() { printf 'WARNING: %s\n' "$*" >&2; }
+die() { printf 'ERROR: %s\n' "$*" >&2; exit 1; }
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || die "Required command not found: $1"
+}
+
+is_true() {
+  case "$1" in
+    true|TRUE|1|yes|YES|y|Y) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+cleanup() {
+  if [[ -n "${pf_pid}" ]]; then
+    kill "${pf_pid}" >/dev/null 2>&1 || true
+  fi
+  if [[ -n "${tmp_env}" && -f "${tmp_env}" ]]; then
+    rm -f "${tmp_env}"
+  fi
+  if is_true "${CLEANUP}"; then
+    "${KUBECTL}" -n "${NS}" delete hermesagent "${AGENT}" --ignore-not-found=true >/dev/null 2>&1 || true
+    if [[ "${created_secret}" == "true" ]]; then
+      "${KUBECTL}" -n "${NS}" delete secret "${AGENT}-model" --ignore-not-found=true >/dev/null 2>&1 || true
+    fi
+  fi
+}
+trap cleanup EXIT
+
+need "${KUBECTL}"
+need curl
+need python3
+
+if is_true "${HELM_INSTALL}"; then
+  need "${HELM}"
+  log "Installing/upgrading Helm release ${HELM_RELEASE} in namespace ${NS}"
+  # shellcheck disable=SC2086 # HELM_ARGS intentionally allows callers to pass multiple Helm flags.
+  "${HELM}" upgrade --install "${HELM_RELEASE}" "${HELM_CHART}" \
+    --namespace "${NS}" \
+    --create-namespace \
+    --wait \
+    --timeout "${ROLLOUT_TIMEOUT}" \
+    ${HELM_ARGS}
+else
+  log "Ensuring namespace ${NS} exists"
+  "${KUBECTL}" get namespace "${NS}" >/dev/null
+fi
+
+if [[ -z "${OPERATOR_DEPLOYMENT}" ]]; then
+  OPERATOR_DEPLOYMENT="$(${KUBECTL} -n "${NS}" get deploy \
+    -l 'control-plane=controller-manager' \
+    -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)"
+fi
+if [[ -z "${OPERATOR_DEPLOYMENT}" ]]; then
+  OPERATOR_DEPLOYMENT="${HELM_RELEASE}-controller-manager"
+fi
+
+log "Checking operator rollout deployment/${OPERATOR_DEPLOYMENT} in namespace ${NS}"
+"${KUBECTL}" -n "${NS}" rollout status "deployment/${OPERATOR_DEPLOYMENT}" --timeout="${ROLLOUT_TIMEOUT}"
+"${KUBECTL}" -n "${NS}" wait --for=condition=Available "deployment/${OPERATOR_DEPLOYMENT}" --timeout="${ROLLOUT_TIMEOUT}"
+"${KUBECTL}" -n "${NS}" get deploy "${OPERATOR_DEPLOYMENT}" -o wide
+
+if [[ -n "${ANTHROPIC_API_KEY:-}${OPENAI_API_KEY:-}" ]]; then
+  tmp_env="$(mktemp "${TMPDIR:-/tmp}/hermes-smoke-env.XXXXXX")"
+  chmod 600 "${tmp_env}"
+  if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+    printf 'ANTHROPIC_API_KEY=%s\n' "${ANTHROPIC_API_KEY}" >>"${tmp_env}"
+  fi
+  if [[ -n "${OPENAI_API_KEY:-}" ]]; then
+    printf 'OPENAI_API_KEY=%s\n' "${OPENAI_API_KEY}" >>"${tmp_env}"
+  fi
+  log "Applying smoke model Secret ${AGENT}-model"
+  "${KUBECTL}" -n "${NS}" create secret generic "${AGENT}-model" \
+    --from-env-file="${tmp_env}" \
+    --dry-run=client -o yaml | "${KUBECTL}" apply -f -
+  created_secret=true
+else
+  warn "No ANTHROPIC_API_KEY or OPENAI_API_KEY supplied; applying agent without model Secret and skipping answer check"
+fi
+
+log "Applying HermesAgent ${AGENT}"
+if [[ "${created_secret}" == "true" ]]; then
+  "${KUBECTL}" -n "${NS}" apply -f - <<EOF
+apiVersion: agents.hermeum.app/v1alpha1
+kind: HermesAgent
+metadata:
+  name: ${AGENT}
+spec:
+  hermes:
+    config:
+      apiServer:
+        enabled: true
+        port: ${API_PORT}
+      raw:
+        model:
+          provider: ${MODEL_PROVIDER}
+          default: ${MODEL_DEFAULT}
+    envFrom:
+      - secretRef:
+          name: ${AGENT}-model
+EOF
+else
+  "${KUBECTL}" -n "${NS}" apply -f - <<EOF
+apiVersion: agents.hermeum.app/v1alpha1
+kind: HermesAgent
+metadata:
+  name: ${AGENT}
+spec:
+  hermes:
+    config:
+      apiServer:
+        enabled: true
+        port: ${API_PORT}
+      raw:
+        model:
+          provider: ${MODEL_PROVIDER}
+          default: ${MODEL_DEFAULT}
+EOF
+fi
+
+log "Waiting for reconciled StatefulSet ${AGENT}"
+"${KUBECTL}" -n "${NS}" rollout status "statefulset/${AGENT}" --timeout="${AGENT_TIMEOUT}"
+"${KUBECTL}" -n "${NS}" wait --for=condition=Ready "pod/${AGENT}-0" --timeout="${AGENT_TIMEOUT}"
+pod_phase="$(${KUBECTL} -n "${NS}" get pod "${AGENT}-0" -o jsonpath='{.status.phase}')"
+[[ "${pod_phase}" == "Running" ]] || die "pod/${AGENT}-0 phase is ${pod_phase}, expected Running"
+ha_phase="$(${KUBECTL} -n "${NS}" get hermesagent "${AGENT}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+if [[ "${ha_phase}" != "Running" ]]; then
+  warn "HermesAgent status.phase is '${ha_phase:-<empty>}' (pod is Running/Ready)"
+fi
+"${KUBECTL}" -n "${NS}" get hermesagent "${AGENT}" -o wide
+"${KUBECTL}" -n "${NS}" get pod "${AGENT}-0" -o wide
+
+api_key="$(${KUBECTL} -n "${NS}" get secret "${AGENT}-hermes" -o jsonpath='{.data.API_SERVER_KEY}' | base64 -d)"
+log "Port-forwarding service/${AGENT} to 127.0.0.1:${LOCAL_PORT}"
+pf_log="${TMPDIR:-/tmp}/hermes-agent-smoke-port-forward-${AGENT}.log"
+"${KUBECTL}" -n "${NS}" port-forward "service/${AGENT}" "${LOCAL_PORT}:${API_PORT}" >"${pf_log}" 2>&1 &
+pf_pid=$!
+
+health_ok=false
+for _ in $(seq 1 30); do
+  if curl -fsS --max-time "${CURL_MAX_TIME}" "http://127.0.0.1:${LOCAL_PORT}/health" >/dev/null; then
+    health_ok=true
+    break
+  fi
+  if ! kill -0 "${pf_pid}" >/dev/null 2>&1; then
+    die "kubectl port-forward exited early; log: $(cat "${pf_log}")"
+  fi
+  sleep 2
+done
+[[ "${health_ok}" == "true" ]] || die "Timed out waiting for API /health via port-forward; log: $(cat "${pf_log}")"
+curl -fsS --max-time "${CURL_MAX_TIME}" "http://127.0.0.1:${LOCAL_PORT}/health"
+printf '\n'
+
+if [[ "${RUN_AGENT_QUERY}" == "auto" ]]; then
+  if [[ "${created_secret}" == "true" ]]; then
+    RUN_AGENT_QUERY=true
+  else
+    RUN_AGENT_QUERY=false
+  fi
+fi
+
+if is_true "${RUN_AGENT_QUERY}"; then
+  [[ "${created_secret}" == "true" ]] || die "RUN_AGENT_QUERY=true requires ANTHROPIC_API_KEY or OPENAI_API_KEY"
+  log "Asking agent through OpenAI-compatible API"
+  payload="$(PROMPT="${PROMPT}" python3 - <<'PY'
+import json, os
+print(json.dumps({
+    "model": "hermes-agent",
+    "messages": [{"role": "user", "content": os.environ["PROMPT"]}],
+    "stream": False,
+}))
+PY
+)"
+  auth_header_prefix="Authorization: Bea"
+  auth_header_prefix="${auth_header_prefix}r""er "
+  response="$(curl -fsS --max-time "${CURL_MAX_TIME}" "http://127.0.0.1:${LOCAL_PORT}/v1/chat/completions" \
+    -H "${auth_header_prefix}${api_key}" \
+    -H "Content-Type: application/json" \
+    -d "${payload}")"
+  answer="$(printf '%s' "${response}" | python3 -c 'import json,sys; print(json.load(sys.stdin)["choices"][0]["message"]["content"])')"
+  printf 'Agent answer: %s\n' "${answer}"
+  [[ "${answer}" == *"${EXPECTED_SUBSTRING}"* ]] || die "Agent answer did not contain expected substring: ${EXPECTED_SUBSTRING}"
+
+else
+  log "Skipping agent answer check (set RUN_AGENT_QUERY=true and provide credentials to enable)"
+fi
+
+if is_true "${CLEANUP}"; then
+  log "Cleaning up smoke HermesAgent/Secret (set CLEANUP=false to keep resources)"
+fi
+log "smoke-ok: operator healthy, HermesAgent applied, pod Running/Ready, API health checked"

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -811,6 +811,10 @@ func skillName(s agentsv1alpha1.HermesSkill) string {
 	return strings.TrimSuffix(parts[len(parts)-1], ".md")
 }
 
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
+}
+
 func buildSkillsScript(skills []agentsv1alpha1.HermesSkill) string {
 	desiredNames := make([]string, 0, len(skills))
 	installLines := make([]string, 0, len(skills))
@@ -823,17 +827,17 @@ func buildSkillsScript(skills []agentsv1alpha1.HermesSkill) string {
 		cmd.WriteString("hermes skills install --yes")
 		if s.Category != "" {
 			cmd.WriteString(" --category ")
-			cmd.WriteString(s.Category)
+			cmd.WriteString(shellQuote(s.Category))
 		}
 		if s.Name != "" {
 			cmd.WriteString(" --name ")
-			cmd.WriteString(s.Name)
+			cmd.WriteString(shellQuote(s.Name))
 		}
 		if s.Force {
 			cmd.WriteString(" --force")
 		}
 		cmd.WriteString(" ")
-		cmd.WriteString(s.Identifier)
+		cmd.WriteString(shellQuote(s.Identifier))
 		installLines = append(installLines, cmd.String())
 	}
 

--- a/internal/usecase/hermesagent_statefulset_test.go
+++ b/internal/usecase/hermesagent_statefulset_test.go
@@ -156,7 +156,7 @@ func TestBuildSkillsScript(t *testing.T) {
 			{Identifier: "openai/skills/skill-creator"},
 		})
 
-		wantCmd := "hermes skills install --yes openai/skills/skill-creator"
+		wantCmd := `hermes skills install --yes 'openai/skills/skill-creator'`
 		if !strings.Contains(got, wantCmd) {
 			t.Errorf("expected %q in script, got:\n%s", wantCmd, got)
 		}
@@ -177,7 +177,7 @@ func TestBuildSkillsScript(t *testing.T) {
 			},
 		})
 
-		wantCmd := "hermes skills install --yes --category writing --name my-skill --force https://example.com/SKILL.md"
+		wantCmd := `hermes skills install --yes --category 'writing' --name 'my-skill' --force 'https://example.com/SKILL.md'`
 		if !strings.Contains(got, wantCmd) {
 			t.Errorf("expected %q in script, got:\n%s", wantCmd, got)
 		}
@@ -211,8 +211,22 @@ func TestBuildSkillsScript(t *testing.T) {
 			t.Errorf("expected manifest content, got:\n%s", got)
 		}
 	})
-}
 
+	t.Run("quotes shell metacharacters", func(t *testing.T) {
+		got := buildSkillsScript([]agentsv1alpha1.HermesSkill{
+			{
+				Identifier: `https://example.com/skill; touch /tmp/pwned.md`,
+				Category:   `writing; touch /tmp/category`,
+				Name:       `evil$(touch /tmp/name)`,
+			},
+		})
+
+		wantCmd := `hermes skills install --yes --category 'writing; touch /tmp/category' --name 'evil$(touch /tmp/name)' 'https://example.com/skill; touch /tmp/pwned.md'`
+		if !strings.Contains(got, wantCmd) {
+			t.Errorf("expected quoted install command %q in script, got:\n%s", wantCmd, got)
+		}
+	})
+}
 func TestBuildBundlesScript(t *testing.T) {
 
 	t.Run("minimal", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- add Helm values for Orgo/k3s host-network Kubernetes API connectivity and namespace-scoped team installs
- add namespace-scoped RBAC rendering, watch namespace support, image digest support, and Helm validation for incompatible secure metrics/RBAC settings
- add team-install docs covering CRD ownership, pinned chart/images, External Secrets, admission guardrails, and Orgo/k3s notes
- add `hack/smoke.sh` and `make smoke` for bounded operator -> HermesAgent -> pod ready -> health smoke checks
- quote Hermes skill install arguments to avoid shell metacharacter injection in generated init scripts

## Verification
- `go test ./...`
- `helm lint dist/chart`
- `helm template bad dist/chart -n team-ns -f dist/chart/values-team.yaml --set metrics.secure=true` exits 1 with expected validation error
- `helm template team dist/chart -n team-ns -f dist/chart/values-team.yaml` renders namespaced Role/RoleBinding and no ClusterRole/ClusterRoleBinding for manager RBAC
- `helm template orgo dist/chart -n hermes-agent -f dist/chart/values-orgo-k3s.yaml` renders `hostNetwork: true`, `dnsPolicy: ClusterFirstWithHostNet`, and localhost Kubernetes API env vars
- `bash -n hack/smoke.sh`

## Notes
This PR does not run the live smoke against a cluster; the previous Orgo smoke established the need for the host-network API workaround, and this PR packages that path into chart/docs/smoke tooling.
