### PR TITLE
feat: add devops agent example

### DIFF
--- a/config/samples/devops_agent.yaml
+++ b/config/samples/devops_agent.yaml
@@ -1,0 +1,72 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: devops-agent-view
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+  - kind: ServiceAccount
+    name: devops-agent
+    namespace: default
+# ---
+# apiVersion: v1
+# kind: Secret
+# metadata:
+#   name: devops-agent-secrets
+# stringData:
+#   OLLAMA_API_KEY: ""
+#   SLACK_BOT_TOKEN: ""
+#   SLACK_APP_TOKEN: ""
+---
+apiVersion: agents.hermeum.app/v1alpha1
+kind: HermesAgent
+metadata:
+  name: devops-agent
+spec:
+  security:
+    rbac:
+      createServiceAccount: true
+  hermes:
+    config:
+      raw:
+        model:
+          base_url: https://ollama.com/v1
+          default: kimi-k2.6
+          provider: ollama-cloud
+    env:
+      - name: SLACK_HOME_CHANNEL
+        value: C0BBJ8SLA2X
+      - name: SLACK_ALLOWED_USERS
+        value: "U01NC888PJT"
+    envFrom:
+      - secretRef:
+          name: devops-agent-secrets
+    workspace:
+      files:
+        SOUL.md: |
+          You are a DevOps assistant with read-only access to a Kubernetes cluster via `kubectl`.
+
+          - Use `kubectl` to inspect real cluster state before drawing any conclusions
+          - Diagnose issues clearly: what is wrong, why, and what to do next
+          - Never create, patch, or delete resources — read-only only
+        .profile: |
+          export PATH="$HERMES_HOME/.local/bin:$PATH"
+    initChownData: true
+    initScripts:
+      - name: install-kubectl
+        script: |
+          KUBECTL_BIN=$HERMES_HOME/.local/bin/kubectl
+          if [ -x "$KUBECTL_BIN" ]; then
+            echo "kubectl already installed, skipping"
+            exit 0
+          fi
+          mkdir -p $HERMES_HOME/.local/bin
+          KUBECTL_VERSION=$(curl -L -s https://dl.k8s.io/release/stable.txt)
+          curl -L "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" -o /tmp/kubectl
+          curl -L "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl.sha256" -o /tmp/kubectl.sha256
+          echo "$(cat /tmp/kubectl.sha256)  /tmp/kubectl" | sha256sum --check
+          chmod +x /tmp/kubectl
+          mv /tmp/kubectl $KUBECTL_BIN
+          echo "kubectl installed: $($KUBECTL_BIN version --client)"

--- a/config/samples/devops_agent.yaml
+++ b/config/samples/devops_agent.yaml
@@ -10,15 +10,15 @@ subjects:
   - kind: ServiceAccount
     name: devops-agent
     namespace: default
-# ---
-# apiVersion: v1
-# kind: Secret
-# metadata:
-#   name: devops-agent-secrets
-# stringData:
-#   OLLAMA_API_KEY: ""
-#   SLACK_BOT_TOKEN: ""
-#   SLACK_APP_TOKEN: ""
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: devops-agent-secrets
+stringData:
+  OLLAMA_API_KEY: ""
+  SLACK_BOT_TOKEN: ""
+  SLACK_APP_TOKEN: ""
 ---
 apiVersion: agents.hermeum.app/v1alpha1
 kind: HermesAgent


### PR DESCRIPTION
## Summary

- Adds `config/samples/devops_agent.yaml` — a HermesAgent configured as a read-only Kubernetes DevOps assistant using Ollama (kimi-k2.6), with a `ClusterRoleBinding` to the built-in `view` ClusterRole and a `kubectl` install init script
- Adds `config/samples/crashing_pod.yaml` — a minimal CrashLoopBackOff pod for testing the devops agent's diagnostic capabilities

## Test plan

- [x] Deploy `devops_agent.yaml` and ask the agent to diagnose the crashing pod
- [x] Verify `kubectl` is available in the agent shell after init script runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)