### PR TITLE
refactor: rename ExtraEnv to Env on SearXNG and Camofox

### DIFF
--- a/api/v1alpha1/hermesagent_types.go
+++ b/api/v1alpha1/hermesagent_types.go
@@ -976,10 +976,10 @@ type SearXNG struct {
 	// +optional
 	Persistence *SearXNGPersistence `json:"persistence,omitempty"`
 
-	// ExtraEnv specifies additional environment variables for the SearXNG
+	// Env specifies additional environment variables for the SearXNG
 	// sidecar container, merged with the operator-managed variables.
 	// +optional
-	ExtraEnv []corev1.EnvVar `json:"extraEnv,omitempty"`
+	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 
 // GetResources returns the SearXNG container resource requirements.
@@ -990,12 +990,12 @@ func (s *SearXNG) GetResources() corev1.ResourceRequirements {
 	return corev1.ResourceRequirements{}
 }
 
-// GetExtraEnv returns the additional environment variables for the SearXNG container.
-func (s *SearXNG) GetExtraEnv() []corev1.EnvVar {
+// GetEnv returns the additional environment variables for the SearXNG container.
+func (s *SearXNG) GetEnv() []corev1.EnvVar {
 	if s == nil {
 		return nil
 	}
-	return s.ExtraEnv
+	return s.Env
 }
 
 // GetPersistence returns the SearXNG persistence configuration, if any.
@@ -1108,10 +1108,10 @@ type Camofox struct {
 	// state is lost on restart.
 	// +optional
 	Persistence CamofoxPersistenceSpec `json:"persistence,omitempty"`
-	// ExtraEnv specifies additional environment variables for the Camofox
+	// Env specifies additional environment variables for the Camofox
 	// sidecar container, merged with the operator-managed variables.
 	// +optional
-	ExtraEnv []corev1.EnvVar `json:"extraEnv,omitempty"`
+	Env []corev1.EnvVar `json:"env,omitempty"`
 }
 
 // IsEnabled reports whether the Camofox sidecar should be created.
@@ -1142,12 +1142,12 @@ func (c *Camofox) GetResources() corev1.ResourceRequirements {
 	return corev1.ResourceRequirements{}
 }
 
-// GetExtraEnv returns the additional environment variables for the Camofox container.
-func (c *Camofox) GetExtraEnv() []corev1.EnvVar {
+// GetEnv returns the additional environment variables for the Camofox container.
+func (c *Camofox) GetEnv() []corev1.EnvVar {
 	if c == nil {
 		return nil
 	}
-	return c.ExtraEnv
+	return c.Env
 }
 
 // GetPersistence returns a pointer to the Camofox persistence configuration.

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -38,8 +38,8 @@ func (in *Camofox) DeepCopyInto(out *Camofox) {
 		(*in).DeepCopyInto(*out)
 	}
 	in.Persistence.DeepCopyInto(&out.Persistence)
-	if in.ExtraEnv != nil {
-		in, out := &in.ExtraEnv, &out.ExtraEnv
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
 		*out = make([]corev1.EnvVar, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
@@ -1033,8 +1033,8 @@ func (in *SearXNG) DeepCopyInto(out *SearXNG) {
 		*out = new(SearXNGPersistence)
 		(*in).DeepCopyInto(*out)
 	}
-	if in.ExtraEnv != nil {
-		in, out := &in.ExtraEnv, &out.ExtraEnv
+	if in.Env != nil {
+		in, out := &in.Env, &out.Env
 		*out = make([]corev1.EnvVar, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])

--- a/config/crd/bases/agents.hermeum.app_hermesagents.yaml
+++ b/config/crd/bases/agents.hermeum.app_hermesagents.yaml
@@ -54,9 +54,9 @@ spec:
                     default: false
                     description: Enabled enables the Camofox sidecar for browser automation
                     type: boolean
-                  extraEnv:
+                  env:
                     description: |-
-                      ExtraEnv specifies additional environment variables for the Camofox
+                      Env specifies additional environment variables for the Camofox
                       sidecar container, merged with the operator-managed variables.
                     items:
                       description: EnvVar represents an environment variable present
@@ -4746,9 +4746,9 @@ spec:
                     description: Enabled enables the SearXNG sidecar that is used
                       by the web_search tool.
                     type: boolean
-                  extraEnv:
+                  env:
                     description: |-
-                      ExtraEnv specifies additional environment variables for the SearXNG
+                      Env specifies additional environment variables for the SearXNG
                       sidecar container, merged with the operator-managed variables.
                     items:
                       description: EnvVar represents an environment variable present

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -575,7 +575,7 @@ func buildSearXNGContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulS
 					},
 				},
 			},
-		}, sx.GetExtraEnv()...),
+		}, sx.GetEnv()...),
 		Resources: sx.GetResources(),
 		VolumeMounts: []corev1.VolumeMount{
 			{Name: searxngConfigVolume, MountPath: searxngConfigMount},
@@ -667,7 +667,7 @@ func buildCamofoxContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulS
 		Name:            camofoxContainerName,
 		Image:           cx.GetImage(),
 		ImagePullPolicy: corev1.PullIfNotPresent,
-		Env:             cx.GetExtraEnv(),
+		Env:             cx.GetEnv(),
 		Resources:       cx.GetResources(),
 		SecurityContext: buildCamofoxContainerSecurityContext(),
 		VolumeMounts: []corev1.VolumeMount{


### PR DESCRIPTION
## Summary

- Renamed `ExtraEnv` field to `Env` (JSON tag `extraEnv` → `env`) on both `SearXNG` and `Camofox` structs in `api/v1alpha1/hermesagent_types.go`
- Renamed `GetExtraEnv()` methods to `GetEnv()` on both types
- Updated call sites in `internal/usecase/hermesagent_statefulset.go`
- Regenerated `zz_generated.deepcopy.go` and `config/crd/bases/agents.hermeum.app_hermesagents.yaml`

## Why

The `Hermes` struct uses `Env` / `env` for its environment variable field. Using `ExtraEnv` / `extraEnv` on the sidecar structs was inconsistent — this rename brings all three structs in line with the same naming convention.

## Reviewer notes

This is a **breaking change** to the CRD API: existing `HermesAgent` resources that set `spec.searxng.extraEnv` or `spec.camofox.extraEnv` will need to be updated to `spec.searxng.env` / `spec.camofox.env` after the CRD is upgraded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)