### PR TITLE
docs: update extraEnv to env for SearXNG and Camofox in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -392,7 +392,7 @@ searxng:
     size: 1Gi                      # optional; defaults to 1Gi
     storageClassName: standard     # optional; omit to use the cluster default StorageClass
     existingClaim: my-searxng-pvc  # optional; omit to provision a new PVC automatically
-  extraEnv:                        # optional; additional env vars for the SearXNG container
+  env:                             # optional; additional env vars for the SearXNG container
     - name: SEARXNG_SECRET
       value: my-secret
 ```
@@ -420,7 +420,7 @@ camofox:
     size: 1Gi                      # optional; defaults to 1Gi
     storageClassName: standard     # optional; omit to use the cluster default StorageClass
     existingClaim: my-camofox-pvc  # optional; omit to provision a new PVC automatically
-  extraEnv:                        # optional; additional env vars for the Camofox container
+  env:                             # optional; additional env vars for the Camofox container
     - name: DISPLAY
       value: ":99"
 ```


### PR DESCRIPTION
## Summary

- Updates the `extraEnv` field to `env` in the `searxng` and `camofox` configuration examples in the README, matching the rename introduced in #47.

## Test plan

- [x] Confirm the README examples now show `env` instead of `extraEnv` for both `searxng` and `camofox` sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)