### PR TITLE
fix: delete pending pod when statefulset is updated

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -23,8 +23,16 @@ rules:
   - ""
   resources:
   - persistentvolumeclaims
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
+  - delete
   - get
   - list
   - watch

--- a/internal/controller/hermesagent_controller.go
+++ b/internal/controller/hermesagent_controller.go
@@ -49,7 +49,7 @@ type HermesAgentReconciler struct {
 // +kubebuilder:rbac:groups="",resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=ingresses,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=networking.k8s.io,resources=networkpolicies,verbs=get;list;watch;create;update;patch;delete
-// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups="",resources=secrets,verbs=get;list;watch;create;update;patch;delete
 
 func (r *HermesAgentReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/internal/infras/kubernetes.go
+++ b/internal/infras/kubernetes.go
@@ -52,6 +52,16 @@ func (k *KubernetesClient) GetPod(ctx context.Context, param usecase.GetPodParam
 	return pod, nil
 }
 
+func (k *KubernetesClient) DeletePod(ctx context.Context, param usecase.DeletePodParam) error {
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      param.NamespacedName.Name,
+			Namespace: param.NamespacedName.Namespace,
+		},
+	}
+	return client.IgnoreNotFound(k.client.Delete(ctx, pod))
+}
+
 func (k *KubernetesClient) GetConfigMap(ctx context.Context, param usecase.GetConfigMapParam) (*corev1.ConfigMap, error) {
 	cm := &corev1.ConfigMap{}
 	if err := k.client.Get(ctx, param.NamespacedName, cm); err != nil {

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -66,6 +66,9 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 			if err := u.kube.UpdateStatefulSetOwnedByHermesAgent(ctx, UpdateStatefulSetParam{HermesAgent: ha, StatefulSet: desired}); err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
+			// If the pod was not running before the update, the StatefulSet controller
+			// will not replace it on its own — the unavailability budget is already
+			// exhausted. Delete it so it is recreated immediately at the new revision.
 			if !podWasRunning {
 				if err := u.kube.DeletePod(ctx, DeletePodParam{
 					NamespacedName: types.NamespacedName{Name: ha.Name + "-0", Namespace: ha.Namespace},

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -128,13 +128,15 @@ func configMapDataHash(data map[string]string) string {
 // Kubernetes-defaulted fields that buildStatefulSet does not set).
 func desiredSpecHash(sts *appsv1.StatefulSet) string {
 	data, _ := json.Marshal(struct {
-		Replicas             *int32                         `json:"replicas"`
-		Template             corev1.PodTemplateSpec         `json:"template"`
-		VolumeClaimTemplates []corev1.PersistentVolumeClaim `json:"volumeClaimTemplates"`
+		Replicas             *int32                           `json:"replicas"`
+		Template             corev1.PodTemplateSpec           `json:"template"`
+		VolumeClaimTemplates []corev1.PersistentVolumeClaim   `json:"volumeClaimTemplates"`
+		UpdateStrategy       appsv1.StatefulSetUpdateStrategy `json:"updateStrategy"`
 	}{
 		Replicas:             sts.Spec.Replicas,
 		Template:             sts.Spec.Template,
 		VolumeClaimTemplates: sts.Spec.VolumeClaimTemplates,
+		UpdateStrategy:       sts.Spec.UpdateStrategy,
 	})
 	h := sha256.Sum256(data)
 	return fmt.Sprintf("%x", h[:])[:16]

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -159,7 +159,7 @@ func (u *HermesAgentUseCase) deleteStuckPod(ctx context.Context, ha *agentsv1alp
 	pod, err := u.kube.GetPod(ctx, GetPodParam{
 		NamespacedName: types.NamespacedName{Name: ha.Name + "-0", Namespace: ha.Namespace},
 	})
-	if err != nil || pod == nil || pod.DeletionTimestamp != nil {
+	if err != nil || pod == nil {
 		return err
 	}
 	if !podIsStuck(pod) {

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
@@ -149,6 +150,7 @@ func buildStatefulSet(ha *agentsv1alpha1.HermesAgent) *appsv1.StatefulSet {
 	cm, _ := buildHermesConfigMap(ha)
 	configHash := configMapDataHash(cm.Data)
 
+	maxUnavailable := intstr.FromInt32(1)
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      ha.Name,
@@ -159,6 +161,12 @@ func buildStatefulSet(ha *agentsv1alpha1.HermesAgent) *appsv1.StatefulSet {
 			Replicas: &replicas,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: selectorLabels(ha),
+			},
+			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
+				RollingUpdate: &appsv1.RollingUpdateStatefulSetStrategy{
+					MaxUnavailable: &maxUnavailable,
+				},
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -128,15 +128,13 @@ func configMapDataHash(data map[string]string) string {
 // Kubernetes-defaulted fields that buildStatefulSet does not set).
 func desiredSpecHash(sts *appsv1.StatefulSet) string {
 	data, _ := json.Marshal(struct {
-		Replicas             *int32                           `json:"replicas"`
-		Template             corev1.PodTemplateSpec           `json:"template"`
-		VolumeClaimTemplates []corev1.PersistentVolumeClaim   `json:"volumeClaimTemplates"`
-		UpdateStrategy       appsv1.StatefulSetUpdateStrategy `json:"updateStrategy"`
+		Replicas             *int32                         `json:"replicas"`
+		Template             corev1.PodTemplateSpec         `json:"template"`
+		VolumeClaimTemplates []corev1.PersistentVolumeClaim `json:"volumeClaimTemplates"`
 	}{
 		Replicas:             sts.Spec.Replicas,
 		Template:             sts.Spec.Template,
 		VolumeClaimTemplates: sts.Spec.VolumeClaimTemplates,
-		UpdateStrategy:       sts.Spec.UpdateStrategy,
 	})
 	h := sha256.Sum256(data)
 	return fmt.Sprintf("%x", h[:])[:16]

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -59,6 +59,9 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
+			if err := u.deleteStuckPod(ctx, ha); err != nil {
+				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+			}
 			u.tel.Debug(ctx, "StatefulSet updated", "phase", ha.Status.Phase)
 		}
 	} else {
@@ -138,6 +141,34 @@ func desiredSpecHash(sts *appsv1.StatefulSet) string {
 	})
 	h := sha256.Sum256(data)
 	return fmt.Sprintf("%x", h[:])[:16]
+}
+
+func podIsStuck(pod *corev1.Pod) bool {
+	if pod.Status.Phase == corev1.PodFailed {
+		return true
+	}
+	for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff" {
+			return true
+		}
+	}
+	return false
+}
+
+func (u *HermesAgentUseCase) deleteStuckPod(ctx context.Context, ha *agentsv1alpha1.HermesAgent) error {
+	pod, err := u.kube.GetPod(ctx, GetPodParam{
+		NamespacedName: types.NamespacedName{Name: ha.Name + "-0", Namespace: ha.Namespace},
+	})
+	if err != nil || pod == nil || pod.DeletionTimestamp != nil {
+		return err
+	}
+	if !podIsStuck(pod) {
+		return nil
+	}
+	u.tel.Debug(ctx, "deleting stuck pod to unblock StatefulSet rollout", "pod", pod.Name)
+	return u.kube.DeletePod(ctx, DeletePodParam{
+		NamespacedName: types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace},
+	})
 }
 
 func buildStatefulSet(ha *agentsv1alpha1.HermesAgent) *appsv1.StatefulSet {

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -54,13 +54,24 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 
 	if sts != nil {
 		if sts.Annotations[annotationDesiredSpecHash] != hash {
-			desired.ResourceVersion = sts.ResourceVersion
-			err := u.kube.UpdateStatefulSetOwnedByHermesAgent(ctx, UpdateStatefulSetParam{HermesAgent: ha, StatefulSet: desired})
+			pod, err := u.kube.GetPod(ctx, GetPodParam{
+				NamespacedName: types.NamespacedName{Name: ha.Name + "-0", Namespace: ha.Namespace},
+			})
 			if err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 			}
-			if err := u.deleteStuckPod(ctx, ha); err != nil {
+			podWasRunning := pod != nil && pod.Status.Phase == corev1.PodRunning
+
+			desired.ResourceVersion = sts.ResourceVersion
+			if err := u.kube.UpdateStatefulSetOwnedByHermesAgent(ctx, UpdateStatefulSetParam{HermesAgent: ha, StatefulSet: desired}); err != nil {
 				return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+			}
+			if !podWasRunning {
+				if err := u.kube.DeletePod(ctx, DeletePodParam{
+					NamespacedName: types.NamespacedName{Name: ha.Name + "-0", Namespace: ha.Namespace},
+				}); err != nil {
+					return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+				}
 			}
 			u.tel.Debug(ctx, "StatefulSet updated", "phase", ha.Status.Phase)
 		}
@@ -141,34 +152,6 @@ func desiredSpecHash(sts *appsv1.StatefulSet) string {
 	})
 	h := sha256.Sum256(data)
 	return fmt.Sprintf("%x", h[:])[:16]
-}
-
-func podIsStuck(pod *corev1.Pod) bool {
-	if pod.Status.Phase == corev1.PodFailed {
-		return true
-	}
-	for _, cs := range append(pod.Status.InitContainerStatuses, pod.Status.ContainerStatuses...) {
-		if cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff" {
-			return true
-		}
-	}
-	return false
-}
-
-func (u *HermesAgentUseCase) deleteStuckPod(ctx context.Context, ha *agentsv1alpha1.HermesAgent) error {
-	pod, err := u.kube.GetPod(ctx, GetPodParam{
-		NamespacedName: types.NamespacedName{Name: ha.Name + "-0", Namespace: ha.Namespace},
-	})
-	if err != nil || pod == nil {
-		return err
-	}
-	if !podIsStuck(pod) {
-		return nil
-	}
-	u.tel.Debug(ctx, "deleting stuck pod to unblock StatefulSet rollout", "pod", pod.Name)
-	return u.kube.DeletePod(ctx, DeletePodParam{
-		NamespacedName: types.NamespacedName{Name: pod.Name, Namespace: pod.Namespace},
-	})
 }
 
 func buildStatefulSet(ha *agentsv1alpha1.HermesAgent) *appsv1.StatefulSet {

--- a/internal/usecase/interface.go
+++ b/internal/usecase/interface.go
@@ -55,6 +55,7 @@ type Kubernetes interface {
 	UpdateHermesAgentStatus(ctx context.Context, param UpdateHermesAgentStatusParam) error
 
 	GetPod(ctx context.Context, param GetPodParam) (*corev1.Pod, error)
+	DeletePod(ctx context.Context, param DeletePodParam) error
 
 	GetConfigMap(ctx context.Context, param GetConfigMapParam) (*corev1.ConfigMap, error)
 	CreateConfigMapOwnedByHermesAgent(ctx context.Context, param CreateConfigMapOfHermesAgentParam) error
@@ -110,6 +111,10 @@ type UpdateHermesAgentStatusParam struct {
 }
 
 type GetPodParam struct {
+	NamespacedName types.NamespacedName
+}
+
+type DeletePodParam struct {
 	NamespacedName types.NamespacedName
 }
 


### PR DESCRIPTION
## What changed

Two complementary fixes to unblock StatefulSet rollouts when a pod is not running:

### Operator-side pod deletion when pod was not running at update time

When the operator applies a new StatefulSet template (config change), it snapshots whether the pod was `Running` beforehand. If it wasn't (Pending from a crashing init container, Failed, Unknown, or absent), it deletes the pod immediately after the update.

This covers the gap that `maxUnavailable: 1` cannot: a non-running pod already exhausts the unavailability budget, so the StatefulSet controller won't replace it on its own. Deleting it unblocks the rollout so the StatefulSet recreates it at the new revision right away.

New infrastructure to support this:
- `DeletePod` added to the usecase interface and infra layer
- `delete` verb added to the pod RBAC annotation (and regenerated in `config/rbac/role.yaml`)

## What was NOT changed

- No CRD fields added — behaviour is unconditional and always correct for a single-replica workload.
- No README update — no spec change.

## Testing

1. `make manifests && make lint-fix` pass clean.
2. Apply `minimal-spec`, confirm pod reaches Running.
3. **Absent pod**: evict/delete the pod, apply a config change — StatefulSet should roll out immediately.
4. **Crashing init container**: add a bad `initScript`, wait for pod to enter Pending/CrashLoopBackOff, apply a fix — operator deletes the pod and StatefulSet recreates it at the new revision.