### PR TITLE
feat: add status.reason field to surface pod crash/pending cause

### DIFF
--- a/api/v1alpha1/hermesagent_types.go
+++ b/api/v1alpha1/hermesagent_types.go
@@ -1332,6 +1332,12 @@ type HermesAgentStatus struct {
 	// +optional
 	Phase HermesAgentPhase `json:"phase,omitempty"`
 
+	// reason is a short, CamelCase code indicating why the agent is in its current phase.
+	// Populated when the pod is pending (e.g. "Unschedulable") or unhealthy
+	// (e.g. "CrashLoopBackOff", "OOMKilled"). Empty when the agent is running normally.
+	// +optional
+	Reason string `json:"reason,omitempty"`
+
 	// conditions represent the current state of the HermesAgent resource.
 	// Each condition has a unique type and reflects the status of a specific aspect of the resource.
 	//

--- a/config/crd/bases/agents.hermeum.app_hermesagents.yaml
+++ b/config/crd/bases/agents.hermeum.app_hermesagents.yaml
@@ -6962,6 +6962,12 @@ spec:
                   phase is the current lifecycle phase of the HermesAgent, mirroring the underlying pod phase.
                   One of Pending, Running, Succeeded, Failed, Unknown, or Suspended.
                 type: string
+              reason:
+                description: |-
+                  reason is a short, CamelCase code indicating why the agent is in its current phase.
+                  Populated when the pod is pending (e.g. "Unschedulable") or unhealthy
+                  (e.g. "CrashLoopBackOff", "OOMKilled"). Empty when the agent is running normally.
+                type: string
             type: object
         required:
         - spec

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -96,23 +96,25 @@ func (u *HermesAgentUseCase) deriveStatus(ctx context.Context, ha *agentsv1alpha
 		return agentsv1alpha1.PhasePending, ""
 	}
 
-	var phase agentsv1alpha1.HermesAgentPhase
-	switch pod.Status.Phase {
-	case corev1.PodPending:
-		phase = agentsv1alpha1.PhasePending
-	case corev1.PodRunning:
-		phase = agentsv1alpha1.PhaseRunning
-	case corev1.PodSucceeded:
-		phase = agentsv1alpha1.PhaseSucceeded
-	case corev1.PodFailed:
-		phase = agentsv1alpha1.PhaseFailed
-	default:
-		phase = agentsv1alpha1.PhaseUnknown
-	}
-	return phase, podReason(pod)
+	return hermesAgentPhase(pod), hermesAgentReason(pod)
 }
 
-func podReason(pod *corev1.Pod) string {
+func hermesAgentPhase(pod *corev1.Pod) agentsv1alpha1.HermesAgentPhase {
+	switch pod.Status.Phase {
+	case corev1.PodPending:
+		return agentsv1alpha1.PhasePending
+	case corev1.PodRunning:
+		return agentsv1alpha1.PhaseRunning
+	case corev1.PodSucceeded:
+		return agentsv1alpha1.PhaseSucceeded
+	case corev1.PodFailed:
+		return agentsv1alpha1.PhaseFailed
+	default:
+		return agentsv1alpha1.PhaseUnknown
+	}
+}
+
+func hermesAgentReason(pod *corev1.Pod) string {
 	if pod.Status.Phase == corev1.PodPending {
 		for _, c := range pod.Status.Conditions {
 			if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionFalse && c.Reason != "" {

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -69,7 +69,7 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 	}
 
 	ha.Status.ManagedResources.StatefulSet = ha.Name
-	ha.Status.Phase = u.derivePhase(ctx, ha)
+	ha.Status.Phase, ha.Status.Reason = u.deriveStatus(ctx, ha)
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
@@ -82,31 +82,70 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 	return ctrl.Result{}, nil
 }
 
-func (u *HermesAgentUseCase) derivePhase(ctx context.Context, ha *agentsv1alpha1.HermesAgent) agentsv1alpha1.HermesAgentPhase {
+func (u *HermesAgentUseCase) deriveStatus(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (agentsv1alpha1.HermesAgentPhase, string) {
 	if ha.IsSuspended() {
-		return agentsv1alpha1.PhaseSuspended
+		return agentsv1alpha1.PhaseSuspended, ""
 	}
 	pod, err := u.kube.GetPod(ctx, GetPodParam{
 		NamespacedName: types.NamespacedName{Name: ha.Name + "-0", Namespace: ha.Namespace},
 	})
 	if err != nil {
-		return agentsv1alpha1.PhaseUnknown
+		return agentsv1alpha1.PhaseUnknown, ""
 	}
 	if pod == nil {
-		return agentsv1alpha1.PhasePending
+		return agentsv1alpha1.PhasePending, ""
 	}
+
+	var phase agentsv1alpha1.HermesAgentPhase
 	switch pod.Status.Phase {
 	case corev1.PodPending:
-		return agentsv1alpha1.PhasePending
+		phase = agentsv1alpha1.PhasePending
 	case corev1.PodRunning:
-		return agentsv1alpha1.PhaseRunning
+		phase = agentsv1alpha1.PhaseRunning
 	case corev1.PodSucceeded:
-		return agentsv1alpha1.PhaseSucceeded
+		phase = agentsv1alpha1.PhaseSucceeded
 	case corev1.PodFailed:
-		return agentsv1alpha1.PhaseFailed
+		phase = agentsv1alpha1.PhaseFailed
 	default:
-		return agentsv1alpha1.PhaseUnknown
+		phase = agentsv1alpha1.PhaseUnknown
 	}
+	return phase, podReason(pod)
+}
+
+func podReason(pod *corev1.Pod) string {
+	if pod.Status.Phase == corev1.PodPending {
+		for _, c := range pod.Status.Conditions {
+			if c.Type == corev1.PodScheduled && c.Status == corev1.ConditionFalse && c.Reason != "" {
+				return c.Reason
+			}
+		}
+		for _, cs := range pod.Status.InitContainerStatuses {
+			if w := cs.State.Waiting; w != nil && w.Reason != "" {
+				return w.Reason
+			}
+		}
+		return ""
+	}
+
+	for _, cs := range pod.Status.InitContainerStatuses {
+		if t := cs.State.Terminated; t != nil && t.ExitCode != 0 && t.Reason != "" {
+			return t.Reason
+		}
+		if w := cs.State.Waiting; w != nil && w.Reason != "" {
+			return w.Reason
+		}
+	}
+
+	for _, cs := range pod.Status.ContainerStatuses {
+		if w := cs.State.Waiting; w != nil && w.Reason != "" {
+			return w.Reason
+		}
+		if t := cs.LastTerminationState.Terminated; t != nil && t.ExitCode != 0 && t.Reason != "" {
+			return t.Reason
+		}
+	}
+
+	return pod.Status.Reason
 }
 
 func configMapDataHash(data map[string]string) string {


### PR DESCRIPTION
## Summary

- Adds a `reason` string field to `HermesAgentStatus` that exposes the short CamelCase reason code from the underlying pod (e.g. `CrashLoopBackOff`, `OOMKilled`, `Unschedulable`, `ImagePullBackOff`)
- Refactors `derivePhase` → `deriveStatus`, which returns both the phase and the reason in a single pod fetch
- Replaces the `podMessage` helper with `podReason` that reads raw reason codes from pod scheduling conditions and container states (no string formatting)
- Regenerated CRD manifest (`config/crd/bases/agents.hermeum.app_hermesagents.yaml`) with the new field

## Motivation

Previously, users had to `kubectl describe pod` to find out why an agent was stuck in `Pending` or crashing. The new `status.reason` field surfaces this directly on the `HermesAgent` CR so it shows up in `kubectl get hermesagent` without any extra lookups.

## Priority of reason sources (highest first)

1. Pod scheduling condition (`Unschedulable`)
2. Init container waiting/termination reason (blocks main container)
3. Main container waiting reason (`CrashLoopBackOff`, `ImagePullBackOff`)
4. Main container last-termination reason (`OOMKilled`, `Error`)
5. Pod-level reason (eviction, etc.)