### PR TITLE
docs: document dotEnv and files subsections under hermes.workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,11 @@ hermes:
 
 ### `hermes.workspace`
 
-Seed files into the agent's home directory before startup. Keys are relative paths; use `/` as a separator for subdirectories.
+Seed files and secrets into the agent's home directory before startup.
+
+#### `files`
+
+Seed files into the agent's home directory. Keys are relative paths; use `/` as a separator for subdirectories.
 
 ```yaml
 hermes:
@@ -163,6 +167,18 @@ hermes:
       skills/custom/SKILL.md: |   # subdirectory path — operator creates parent dirs automatically
         # My Custom Skill
         ...
+```
+
+#### `dotEnv`
+
+Generate a `$HERMES_HOME/.env` file from a Kubernetes Secret. Each key in the Secret becomes a `KEY=VALUE` line in the file. Useful for tools that read `.env` files at startup.
+
+```yaml
+hermes:
+  workspace:
+    dotEnv:                        # optional; omit if no .env file is needed
+      secretRef:
+        name: my-env-secret        # name of the Secret in the same namespace
 ```
 
 


### PR DESCRIPTION
## Summary

- The `dotEnv` field (introduced in b81f54d) was absent from the README, leaving users unaware of the feature.
- Restructured `hermes.workspace` into `#### files` and `#### dotEnv` subsections, mirroring the layout used by `hermes.config`.
- Added a YAML example and description for `dotEnv`: references a Kubernetes Secret whose keys become `KEY=VALUE` lines written to `$HERMES_HOME/.env` via an init container.

## What a reviewer should know

No code changes — docs only. The YAML example matches the `HermesDotEnv.SecretRef` field shape in the Go types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)