### PR TITLE
docs: add skill install section and remove Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,14 +56,6 @@ kubectl get hermesagent my-agent
 kubectl get pods -l app.kubernetes.io/instance=my-agent
 ```
 
-## Examples
-
-Ready-to-apply manifests live in [`config/samples/`](./config/samples/). Each file includes a Secret for credentials and a `HermesAgent` resource. Fill in the Secret values, then apply:
-
-```sh
-kubectl apply -f config/samples/web_search.yaml
-```
-
 ## Create a HermesAgent with the Skill
 
 The `hermes-agent-operator` skill lets a running Hermes agent scaffold and apply `HermesAgent` manifests on your behalf. Install it once into any agent:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ Ready-to-apply manifests live in [`config/samples/`](./config/samples/). Each fi
 kubectl apply -f config/samples/web_search.yaml
 ```
 
+## Create a HermesAgent with the Skill
+
+The `hermes-agent-operator` skill lets a running Hermes agent scaffold and apply `HermesAgent` manifests on your behalf. Install it once into any agent:
+
+```sh
+hermes skills install hermeum/hermes-agent-operator/skills/hermes-agent-operator
+```
+
+Then run the `/hermes-agent-operator` skill to create a custom resource.
+
 ## Configuration
 
 - [`hermes.config`](#hermesconfig)


### PR DESCRIPTION
## Summary

- Adds a new **"Create a HermesAgent with the Skill"** section showing how to install the `hermes-agent-operator` skill and use `/hermes-agent-operator` to scaffold a `HermesAgent` manifest from a running agent
- Removes the Examples section

## Reviewer notes

Pure docs change — no code or CRD changes.