### PR TITLE
fix: shorten Helm controller-manager resource names

### DIFF
--- a/dist/chart/values.yaml
+++ b/dist/chart/values.yaml
@@ -4,7 +4,7 @@
 
 ## String to fully override chart.fullname template
 ##
-# fullnameOverride: ""
+fullnameOverride: "hermes-agent"
 
 ## Configure the controller manager deployment
 ##


### PR DESCRIPTION
## Summary
- The Helm chart deployed the controller pod (and ServiceAccount, RoleBindings, metrics Service) as `hermes-agent-operator-controller-manager`, derived from `Chart.Name` combined with the default release name.
- Sets `fullnameOverride: "hermes-agent"` in `dist/chart/values.yaml` so these resources become `hermes-agent-controller-manager` instead — using the chart's existing built-in override mechanism rather than editing generated templates, `Chart.yaml`, or kustomize config.
- Verified with `helm lint` (passes) and `helm template` (rendered Deployment/RoleBindings/metrics Service all correctly renamed).

## Test plan
- [x] `helm lint dist/chart`
- [x] `helm template dist/chart` — confirm resource names are `hermes-agent-controller-manager` etc.
- [ ] Optional: `make helm-deploy` against a real cluster and confirm the pod comes up as `hermes-agent-controller-manager-*` (not run in this session — no cluster available). Note: upgrading an existing Helm release will recreate resources under the new name (brief pod restart).