### PR TITLE
chore: bump chart version to 0.5.1 and app version to 0.7.0

### DIFF
--- a/dist/chart/Chart.yaml
+++ b/dist/chart/Chart.yaml
@@ -3,8 +3,8 @@ name: hermes-agent-operator
 description: A Helm chart to distribute hermes-agent-operator
 type: application
 
-version: 0.5.0
-appVersion: "0.6.0"
+version: 0.5.1
+appVersion: "0.7.0"
 
 keywords:
   - kubernetes


### PR DESCRIPTION
## Summary
- Bump Helm chart `version` to `0.5.1` and `appVersion` to `0.7.0` in `dist/chart/Chart.yaml`

## Test plan
- N/A (version metadata only)