### PR TITLE
feat: add podAnnotations to trigger StatefulSet pod rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Then run the `/hermes-agent-operator` skill to create a custom resource.
 - [`networking.service`](#networkingservice)
 - [`networking.ingress`](#networkingingress)
 - [`suspend`](#suspend)
+- [`podAnnotations`](#podannotations)
 
 ### `hermes.config`
 
@@ -584,6 +585,17 @@ Pause the agent by scaling its StatefulSet to 0 without deleting the resource or
 
 ```yaml
 suspend: true                      # optional; defaults to false
+```
+
+
+### `podAnnotations`
+
+Add custom annotations to the agent's pod template. Changing any key/value triggers a rolling restart of the StatefulSet's pods — set a key like `rotatedAt` to an RFC3339 timestamp and update it whenever a restart is needed, equivalent to `kubectl rollout restart statefulset`.
+
+```yaml
+podAnnotations:                      # optional
+  rotatedAt: "2026-07-06T12:00:00Z"  # any change here triggers a rolling restart
+  prometheus.io/scrape: "true"       # also usable for ordinary pod annotations
 ```
 
 

--- a/api/v1alpha1/hermesagent_types.go
+++ b/api/v1alpha1/hermesagent_types.go
@@ -1338,6 +1338,12 @@ type HermesAgentSpec struct {
 	// +optional
 	ExtraVolumeMounts []corev1.VolumeMount `json:"extraVolumeMounts,omitempty"`
 
+	// PodAnnotations adds custom annotations to the Hermes agent pod template.
+	// Changing any key (e.g. a timestamp) triggers a rolling restart of the
+	// StatefulSet's pods, mirroring `kubectl rollout restart statefulset`.
+	// +optional
+	PodAnnotations map[string]string `json:"podAnnotations,omitempty"`
+
 	// SearXNG configures an optional SearXNG sidecar used by the web_search tool.
 	// +optional
 	SearXNG *SearXNG `json:"searxng,omitempty"`
@@ -1485,6 +1491,11 @@ func (h *HermesAgent) GetExtraVolumes() []corev1.Volume {
 
 func (h *HermesAgent) GetExtraVolumeMounts() []corev1.VolumeMount {
 	return h.Spec.ExtraVolumeMounts
+}
+
+// GetPodAnnotations returns the custom pod template annotations, if any.
+func (h *HermesAgent) GetPodAnnotations() map[string]string {
+	return h.Spec.PodAnnotations
 }
 
 func (h *HermesAgent) GetSearXNG() *SearXNG {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -349,6 +349,13 @@ func (in *HermesAgentSpec) DeepCopyInto(out *HermesAgentSpec) {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
 	}
+	if in.PodAnnotations != nil {
+		in, out := &in.PodAnnotations, &out.PodAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.SearXNG != nil {
 		in, out := &in.SearXNG, &out.SearXNG
 		*out = new(SearXNG)

--- a/config/crd/bases/agents.hermeum.app_hermesagents.yaml
+++ b/config/crd/bases/agents.hermeum.app_hermesagents.yaml
@@ -4986,6 +4986,14 @@ spec:
                         type: string
                     type: object
                 type: object
+              podAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PodAnnotations adds custom annotations to the Hermes agent pod template.
+                  Changing any key (e.g. a timestamp) triggers a rolling restart of the
+                  StatefulSet's pods, mirroring `kubectl rollout restart statefulset`.
+                type: object
               searxng:
                 description: SearXNG configures an optional SearXNG sidecar used by
                   the web_search tool.

--- a/dist/chart/templates/crd/hermesagents.agents.hermeum.app.yaml
+++ b/dist/chart/templates/crd/hermesagents.agents.hermeum.app.yaml
@@ -4989,6 +4989,14 @@ spec:
                         type: string
                     type: object
                 type: object
+              podAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PodAnnotations adds custom annotations to the Hermes agent pod template.
+                  Changing any key (e.g. a timestamp) triggers a rolling restart of the
+                  StatefulSet's pods, mirroring `kubectl rollout restart statefulset`.
+                type: object
               searxng:
                 description: SearXNG configures an optional SearXNG sidecar used by
                   the web_search tool.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -4994,6 +4994,14 @@ spec:
                         type: string
                     type: object
                 type: object
+              podAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PodAnnotations adds custom annotations to the Hermes agent pod template.
+                  Changing any key (e.g. a timestamp) triggers a rolling restart of the
+                  StatefulSet's pods, mirroring `kubectl rollout restart statefulset`.
+                type: object
               searxng:
                 description: SearXNG configures an optional SearXNG sidecar used by
                   the web_search tool.

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	agentsv1alpha1 "hermeum/hermes-agent-operator/api/v1alpha1"
+	"maps"
 	"sort"
 	"strconv"
 	"strings"
@@ -243,6 +244,8 @@ func buildStatefulSet(ha *agentsv1alpha1.HermesAgent) *appsv1.StatefulSet {
 			},
 		},
 	}
+
+	maps.Copy(sts.Spec.Template.Annotations, ha.GetPodAnnotations())
 
 	sts = buildHermesContainer(ha, sts)
 	sts = buildSearXNGContainer(ha, sts)

--- a/internal/usecase/hermesagent_statefulset_test.go
+++ b/internal/usecase/hermesagent_statefulset_test.go
@@ -67,6 +67,40 @@ func TestDesiredSpecHash(t *testing.T) {
 			t.Error("hash must not change when only ObjectMeta differs")
 		}
 	})
+
+	t.Run("changes when podAnnotations change", func(t *testing.T) {
+		ha := minimalHA()
+		h1 := desiredSpecHash(buildStatefulSet(ha))
+		ha.Spec.PodAnnotations = map[string]string{"rotatedAt": "2026-07-06T12:00:00Z"}
+		if desiredSpecHash(buildStatefulSet(ha)) == h1 {
+			t.Error("expected different hash when podAnnotations change")
+		}
+	})
+}
+
+func TestBuildStatefulSetPodAnnotations(t *testing.T) {
+	t.Run("no extra annotations when unset", func(t *testing.T) {
+		ha := minimalHA()
+		sts := buildStatefulSet(ha)
+		if len(sts.Spec.Template.Annotations) != 1 {
+			t.Errorf("expected only config-hash annotation, got %v", sts.Spec.Template.Annotations)
+		}
+	})
+
+	t.Run("user annotations are merged in", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.PodAnnotations = map[string]string{"rotatedAt": "2026-07-06T12:00:00Z", "prometheus.io/scrape": "true"}
+		sts := buildStatefulSet(ha)
+		if sts.Spec.Template.Annotations["rotatedAt"] != "2026-07-06T12:00:00Z" {
+			t.Error("expected rotatedAt annotation to be present")
+		}
+		if sts.Spec.Template.Annotations["prometheus.io/scrape"] != "true" {
+			t.Error("expected prometheus.io/scrape annotation to be present")
+		}
+		if _, ok := sts.Spec.Template.Annotations[domain+"/config-hash"]; !ok {
+			t.Error("expected config-hash annotation to still be present")
+		}
+	})
 }
 
 func ptrBool(b bool) *bool { return &b }

--- a/skills/hermes-agent-operator/crd.yaml
+++ b/skills/hermes-agent-operator/crd.yaml
@@ -4986,6 +4986,14 @@ spec:
                         type: string
                     type: object
                 type: object
+              podAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  PodAnnotations adds custom annotations to the Hermes agent pod template.
+                  Changing any key (e.g. a timestamp) triggers a rolling restart of the
+                  StatefulSet's pods, mirroring `kubectl rollout restart statefulset`.
+                type: object
               searxng:
                 description: SearXNG configures an optional SearXNG sidecar used by
                   the web_search tool.


### PR DESCRIPTION
## Summary
- Adds `spec.podAnnotations map[string]string` to `HermesAgent`, letting users add custom annotations to the agent's pod template
- Changing any key/value (e.g. a `rotatedAt` timestamp) triggers a rolling restart of the StatefulSet's pods, mirroring `kubectl rollout restart statefulset` — no new reconcile logic was needed since the existing `desiredSpecHash` already hashes the full pod template (including annotations)
- Also usable for ordinary pod annotations (e.g. `prometheus.io/scrape`)

## Test plan
- [x] `go test ./internal/usecase/...` passes, including new tests covering hash-change-on-annotation-change and annotation-merge-with-config-hash behavior
- [x] `go build ./...` and `go vet ./...` clean
- [x] `make lint-fix` — 0 issues
- [x] Regenerated CRD manifests, deepcopy, and Helm chart via `make manifests`, `make generate`, `kubebuilder edit --plugins=helm/v2-alpha`
- [x] README updated with new `podAnnotations` section