### PR TITLE
fix: allow hermes.ports through NetworkPolicy ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -519,6 +519,8 @@ security:
 
 NetworkPolicy configuration. Created only when this block is present.
 
+Ingress is allowed on the API server port (`hermes.config.apiServer.port`), the webhook port (`hermes.config.webhook.port`), and any additional container ports declared in `hermes.ports`. When a NetworkPolicy is enabled, declare every container port you want reachable in `hermes.ports` — otherwise the default-deny policy will block traffic to it, even if a Service routes to it.
+
 ```yaml
 security:
   networkPolicy:                   # optional; omit the entire block to skip NetworkPolicy creation

--- a/internal/usecase/hermesagent_networkpolicy.go
+++ b/internal/usecase/hermesagent_networkpolicy.go
@@ -103,6 +103,19 @@ func buildNetworkPolicyIngress(ha *agentsv1alpha1.HermesAgent, np *agentsv1alpha
 		p := intstr.FromInt32(ha.GetHermes().GetWebhook().GetPort())
 		ports = append(ports, networkingv1.NetworkPolicyPort{Protocol: &tcp, Port: &p})
 	}
+	// Additional container ports declared in hermes.ports are exposed by the
+	// StatefulSet and must also be allowed through the NetworkPolicy ingress,
+	// otherwise the default-deny policy blocks traffic the user intended to
+	// expose. The API server port (and the webhook port, per the documented
+	// contract) should not be repeated in hermes.ports.
+	for _, cp := range ha.GetHermes().GetPorts() {
+		proto := cp.Protocol
+		if proto == "" {
+			proto = corev1.ProtocolTCP
+		}
+		p := intstr.FromInt32(cp.ContainerPort)
+		ports = append(ports, networkingv1.NetworkPolicyPort{Protocol: &proto, Port: &p})
+	}
 	if len(ports) == 0 {
 		return nil
 	}

--- a/internal/usecase/hermesagent_networkpolicy_test.go
+++ b/internal/usecase/hermesagent_networkpolicy_test.go
@@ -1,0 +1,128 @@
+package usecase
+
+import (
+	"testing"
+
+	agentsv1alpha1 "hermeum/hermes-agent-operator/api/v1alpha1"
+
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+)
+
+func networkPolicyIngressPorts(t *testing.T, ha *agentsv1alpha1.HermesAgent) []networkingv1.NetworkPolicyPort {
+	t.Helper()
+	rules := buildNetworkPolicyIngress(ha, &agentsv1alpha1.NetworkPolicy{Enabled: ptrBool(true)})
+	if len(rules) == 0 {
+		return nil
+	}
+	return rules[0].Ports
+}
+
+func assertIngressPort(t *testing.T, ports []networkingv1.NetworkPolicyPort, want corev1.Protocol, port int32) {
+	t.Helper()
+	for _, p := range ports {
+		if p.Port == nil || p.Port.Type != intstr.Int || p.Port.IntVal != port {
+			continue
+		}
+		proto := corev1.ProtocolTCP
+		if p.Protocol != nil {
+			proto = *p.Protocol
+		}
+		if proto != want {
+			t.Errorf("port %d has protocol %s, want %s", port, proto, want)
+			return
+		}
+		return
+	}
+	t.Errorf("port %d not found in ingress ports %v", port, ports)
+}
+
+func TestBuildNetworkPolicyIngress_Ports(t *testing.T) {
+	t.Run("nil when nothing enabled", func(t *testing.T) {
+		ha := minimalHA()
+		if got := networkPolicyIngressPorts(t, ha); got != nil {
+			t.Errorf("expected nil ingress, got %v", got)
+		}
+	})
+
+	t.Run("only api server when only api server enabled", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+			Config: &agentsv1alpha1.HermesConfig{
+				APIServer: &agentsv1alpha1.HermesAPIServer{Enabled: true},
+			},
+		}
+		ports := networkPolicyIngressPorts(t, ha)
+		if len(ports) != 1 {
+			t.Fatalf("expected 1 port, got %d", len(ports))
+		}
+		assertIngressPort(t, ports, corev1.ProtocolTCP, agentsv1alpha1.DefaultAPIServerPort)
+	})
+
+	t.Run("api server and webhook when both enabled", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+			Config: &agentsv1alpha1.HermesConfig{
+				APIServer: &agentsv1alpha1.HermesAPIServer{Enabled: true},
+				Webhook:   &agentsv1alpha1.HermesWebhook{Enabled: true},
+			},
+		}
+		ports := networkPolicyIngressPorts(t, ha)
+		if len(ports) != 2 {
+			t.Fatalf("expected 2 ports, got %d", len(ports))
+		}
+		assertIngressPort(t, ports, corev1.ProtocolTCP, agentsv1alpha1.DefaultAPIServerPort)
+		assertIngressPort(t, ports, corev1.ProtocolTCP, agentsv1alpha1.DefaultWebhookPort)
+	})
+
+	t.Run("includes additional hermes.ports with default TCP", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+			Config: &agentsv1alpha1.HermesConfig{
+				APIServer: &agentsv1alpha1.HermesAPIServer{Enabled: true},
+			},
+			Ports: []corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 9090},
+			},
+		}
+		ports := networkPolicyIngressPorts(t, ha)
+		if len(ports) != 2 {
+			t.Fatalf("expected 2 ports, got %d (%v)", len(ports), ports)
+		}
+		assertIngressPort(t, ports, corev1.ProtocolTCP, agentsv1alpha1.DefaultAPIServerPort)
+		assertIngressPort(t, ports, corev1.ProtocolTCP, 9090)
+	})
+
+	t.Run("respects explicit protocol on additional ports", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+			Config: &agentsv1alpha1.HermesConfig{
+				APIServer: &agentsv1alpha1.HermesAPIServer{Enabled: true},
+			},
+			Ports: []corev1.ContainerPort{
+				{Name: "syslog", ContainerPort: 5140, Protocol: corev1.ProtocolUDP},
+			},
+		}
+		ports := networkPolicyIngressPorts(t, ha)
+		if len(ports) != 2 {
+			t.Fatalf("expected 2 ports, got %d (%v)", len(ports), ports)
+		}
+		assertIngressPort(t, ports, corev1.ProtocolTCP, agentsv1alpha1.DefaultAPIServerPort)
+		assertIngressPort(t, ports, corev1.ProtocolUDP, 5140)
+	})
+
+	t.Run("additional ports alone are allowed", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+			Ports: []corev1.ContainerPort{
+				{Name: "metrics", ContainerPort: 9090},
+			},
+		}
+		ports := networkPolicyIngressPorts(t, ha)
+		if len(ports) != 1 {
+			t.Fatalf("expected 1 port, got %d (%v)", len(ports), ports)
+		}
+		assertIngressPort(t, ports, corev1.ProtocolTCP, 9090)
+	})
+}


### PR DESCRIPTION
## Summary

The NetworkPolicy ingress rule only allowed the API server and webhook ports. When a NetworkPolicy was enabled, additional container ports declared in \`hermes.ports\` were silently blocked by the default-deny policy, even though the StatefulSet and Service exposed them.

This extends \`buildNetworkPolicyIngress\` to also allow the additional container ports declared in \`hermes.ports\`, using each port's declared protocol (defaulting to TCP). They share the same \`From\` peers (allowedIngressCIDRs / allowedIngressNamespaces) as the api-server and webhook ports.

## Why only \`hermes.ports\`?

A NetworkPolicy ingress \`port\` matches the **destination port on the pod** (the container port), not the Service port. \`hermes.ports\` is the authoritative source for "the pod listens here" and is the same field the StatefulSet puts into \`container.Ports\`. Consulting \`networking.service.ports\` would add a second source of truth for the same concept and only matters in the edge case where a user adds a Service \`targetPort\` without declaring the matching container port.

## Changes

- \`internal/usecase/hermesagent_networkpolicy.go\` — \`buildNetworkPolicyIngress\` now appends a \`NetworkPolicyPort\` for each entry in \`ha.GetHermes().GetPorts()\` (protocol defaults to TCP when empty).
- \`internal/usecase/hermesagent_networkpolicy_test.go\` — new unit tests covering: nothing enabled, only api-server, api-server + webhook, additional port with default TCP, explicit UDP protocol, and additional ports alone.
- \`README.md\` — added a note to \`security.networkPolicy\` documenting that ingress is allowed on api-server, webhook, and \`hermes.ports\`, and that users must declare every reachable container port in \`hermes.ports\` when a NetworkPolicy is enabled.

## Verification

- \`make manifests generate\` — no auto-generated changes (no type/marker edits).
- \`make lint-fix\` — 0 issues.
- \`make test\` — all test targets pass.