### PR TITLE
feat: check for skill updates in init-skills container

### DIFF
--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -1044,6 +1044,7 @@ func buildSkillsScript(profile string, skills []agentsv1alpha1.HermesSkill) stri
 	manifestDir := "$HERMES_HOME/.hermes-agent-operator/profiles/" + profile
 	desiredNames := make([]string, 0, len(skills))
 	installLines := make([]string, 0, len(skills))
+	updateLines := make([]string, 0, len(skills))
 
 	for _, s := range skills {
 		name := skillName(s)
@@ -1065,10 +1066,14 @@ func buildSkillsScript(profile string, skills []agentsv1alpha1.HermesSkill) stri
 		cmd.WriteString(" ")
 		cmd.WriteString(s.Identifier)
 		installLines = append(installLines, cmd.String())
+
+		// Pull any newer version of the skill. Idempotent: a no-op when up to date.
+		updateLines = append(updateLines, fmt.Sprintf("hermes skills update -p %q %s || true", profile, name))
 	}
 
 	casePattern := `"` + strings.Join(desiredNames, `"|"`) + `"`
 	installScript := strings.Join(installLines, "\n")
+	updateScript := strings.Join(updateLines, "\n")
 	manifestContent := strings.Join(desiredNames, "\n")
 
 	return fmt.Sprintf(`set -eu
@@ -1089,11 +1094,14 @@ fi
 # Install desired skills
 %s
 
+# Update installed skills to the latest version available
+%s
+
 # Update manifest
 cat > "$MANIFEST" << 'SKILLS_EOF'
 %s
 SKILLS_EOF
-`, manifestDir, manifestDir, casePattern, profile, installScript, manifestContent)
+`, manifestDir, manifestDir, casePattern, profile, installScript, updateScript, manifestContent)
 }
 
 func buildBundlesScript(profile string, bundles []agentsv1alpha1.HermesBundle) string {

--- a/internal/usecase/hermesagent_statefulset_test.go
+++ b/internal/usecase/hermesagent_statefulset_test.go
@@ -282,6 +282,55 @@ func TestBuildSkillsScript(t *testing.T) {
 			t.Errorf("expected manifest path profiles/coder/skills, got:\n%s", got)
 		}
 	})
+
+	t.Run("update command present per skill", func(t *testing.T) {
+		got := buildSkillsScript(hermesDefaultProfile, []agentsv1alpha1.HermesSkill{
+			{Identifier: "openai/skills/skill-creator"},
+		})
+
+		wantUpdate := `hermes skills update -p "default" skill-creator || true`
+		if !strings.Contains(got, wantUpdate) {
+			t.Errorf("expected update command %q in script, got:\n%s", wantUpdate, got)
+		}
+	})
+
+	t.Run("update command uses explicit name", func(t *testing.T) {
+		got := buildSkillsScript(hermesDefaultProfile, []agentsv1alpha1.HermesSkill{
+			{Identifier: "https://example.com/SKILL.md", Name: "my-skill"},
+		})
+
+		wantUpdate := `hermes skills update -p "default" my-skill || true`
+		if !strings.Contains(got, wantUpdate) {
+			t.Errorf("expected update command %q in script, got:\n%s", wantUpdate, got)
+		}
+	})
+
+	t.Run("update command for named profile", func(t *testing.T) {
+		got := buildSkillsScript("coder", []agentsv1alpha1.HermesSkill{
+			{Identifier: "openai/skills/foo"},
+		})
+
+		wantUpdate := `hermes skills update -p "coder" foo || true`
+		if !strings.Contains(got, wantUpdate) {
+			t.Errorf("expected update command %q in script, got:\n%s", wantUpdate, got)
+		}
+	})
+
+	t.Run("update commands for multiple skills", func(t *testing.T) {
+		got := buildSkillsScript(hermesDefaultProfile, []agentsv1alpha1.HermesSkill{
+			{Identifier: "openai/skills/alpha"},
+			{Identifier: "openai/skills/beta.md"},
+		})
+
+		wantUpdate1 := `hermes skills update -p "default" alpha || true`
+		wantUpdate2 := `hermes skills update -p "default" beta || true`
+		if !strings.Contains(got, wantUpdate1) {
+			t.Errorf("expected update command %q in script, got:\n%s", wantUpdate1, got)
+		}
+		if !strings.Contains(got, wantUpdate2) {
+			t.Errorf("expected update command %q in script, got:\n%s", wantUpdate2, got)
+		}
+	})
 }
 
 func TestBuildBundlesScript(t *testing.T) {


### PR DESCRIPTION
## Summary

The `init-skills` init container previously only ran `hermes skills install` per desired skill. While install is idempotent, it does **not** pull upstream updates for already-installed skills — on pod restart, skills stayed frozen at the version first installed.

This adds a `hermes skills update -p <profile> <name>` call after each install so the init container reconciles skills to the latest available version on every pod (re)start.

## Behavior

For each desired skill, the generated init script now runs:
1. `hermes skills install -p "<profile>" --yes [--category ...] [--name ...] [--force] <identifier>` — installs if missing (unchanged)
2. `hermes skills update -p "<profile>" <name> || true` — **NEW**, pulls any newer version

The `update` subcommand is idempotent:
- Prints `No updates available.` and exits 0 when the skill is up to date (no-op on first install, since install just pulled the current latest).
- Pulls the new version when `update_available`.

Wrapped in `|| true` so a transient registry/network failure does not abort the init container under `set -eu` — the skill remains at its currently-installed version and retries on the next pod restart.

## Profile handling

`hermes skills update`/`check` accept the global `-p <profile>` flag (not documented in their subcommand help, but validated and applied), so this works for both the default profile and named profiles (e.g. `coder`) without any active-profile switching.

## First installation

On first install, `install` fetches the latest version, then `update` runs and reports `up_to_date` — a harmless no-op. The order (install before update) is preserved, and `set -eu` ensures a failed install still aborts before update runs.

## `force` field

Unchanged. The existing `force` field still only adds `--force` to the `install` command (bypasses the security-scan verdict), per the existing semantics. It does not affect the update step.

## Test plan

- [x] `TestBuildSkillsScript` — added 4 new subtests covering: update present per skill, update uses explicit name, update for named profile, update for multiple skills
- [x] `make lint-fix` — 0 issues
- [x] `go test ./internal/usecase/` — all pass

## Files changed

- `internal/usecase/hermesagent_statefulset.go` — `buildSkillsScript` emits an update line per skill after the install block
- `internal/usecase/hermesagent_statefulset_test.go` — 4 new subtests in `TestBuildSkillsScript`
