### PR TITLE
chore: drop pinned hermes image tag from minimal_spec example

### DIFF
--- a/skills/hermes-agent-operator/examples/minimal_spec.yaml
+++ b/skills/hermes-agent-operator/examples/minimal_spec.yaml
@@ -11,8 +11,6 @@ metadata:
   name: minimal-spec
 spec:
   hermes:
-    image:
-      tag: v2026.6.5
     config:
       # apiServer:
       #   enabled: true


### PR DESCRIPTION
## Summary

Remove the hardcoded `image.tag: v2026.6.5` from the `minimal_spec` example so it relies on the CRD's default (`latest`), matching the other five examples (`devops_agent`, `github_reviewer`, `web_search`, `multi_profile`, `langfuse_observability`) which already omit it.

## Why

The date-based pin (`v2026.6.5`) goes stale and creates a maintenance burden — the canonical minimal example ships users an outdated Hermes version. Dropping the tag keeps the example evergreen and consistent with the rest of the examples directory.

The CRD already defaults `spec.hermes.image.tag` to `latest` when omitted (`api/v1alpha1/hermesagent_types.go`), and `SKILL.md` documents this as the default behavior.

## Changes

- `skills/hermes-agent-operator/examples/minimal_spec.yaml`: removed the `image:` block (the `tag` was its only field). No auto-generated files touched; `make manifests`/`make generate` not required.

## Validation

YAML validated. Only the two pinned lines were removed.