### PR TITLE
docs: replace SEARXNG_SECRET example with UWSGI_WORKERS

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,8 +464,8 @@ searxng:
     storageClassName: standard     # optional; omit to use the cluster default StorageClass
     existingClaim: my-searxng-pvc  # optional; omit to provision a new PVC automatically
   env:                             # optional; additional env vars for the SearXNG container
-    - name: SEARXNG_SECRET
-      value: my-secret
+    - name: UWSGI_WORKERS
+      value: "4"
 ```
 
 


### PR DESCRIPTION
## Summary

`SEARXNG_SECRET` is set systematically by the operator, so showing it as a user-configurable env var in the README confuses customers into thinking they need to set it themselves.

This replaces the `SEARXNG_SECRET` example with a generic non-secret env var (`UWSGI_WORKERS`) to demonstrate the `searxng.env` field without implying a secret needs to be provided.

## Changes
- `README.md`: swap the `SEARXNG_SECRET` example for `UWSGI_WORKERS` in the `searxng.env` section.