### PR TITLE
fix: inject API_SERVER_*/WEBHOOK_* via .env instead of container env vars

### DIFF
--- a/internal/usecase/hermesagent_hermes_configmap.go
+++ b/internal/usecase/hermesagent_hermes_configmap.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	agentsv1alpha1 "hermeum/hermes-agent-operator/api/v1alpha1"
 	"maps"
+	"strconv"
 	"strings"
 	"time"
 
@@ -201,6 +202,31 @@ func buildHermesConfigMap(ha *agentsv1alpha1.HermesAgent) (*corev1.ConfigMap, er
 				data[key] = content
 			}
 		}
+	}
+
+	// Operator-managed env vars for the dotenv init container. These keys are
+	// mounted (with an Items filter) into init-dotenv so they land in .env.
+	// Non-secret values go in the ConfigMap; secret values (API_SERVER_KEY,
+	// WEBHOOK_SECRET) are in the operator Secret and mounted separately.
+	if apiServer := ha.GetHermes().GetAPIServer(); apiServer.IsEnabled() {
+		data["API_SERVER_ENABLED"] = "true"
+		// The default bind is 127.0.0.1, which is unreachable from outside
+		// the pod; bind all interfaces so the Service can route to it.
+		data["API_SERVER_HOST"] = "0.0.0.0"
+		data["API_SERVER_PORT"] = strconv.Itoa(int(apiServer.GetPort()))
+		if origins := apiServer.GetCORSOrigins(); len(origins) > 0 {
+			data["API_SERVER_CORS_ORIGINS"] = strings.Join(origins, ",")
+		}
+	}
+	if webhook := ha.GetHermes().GetWebhook(); webhook.IsEnabled() {
+		data["WEBHOOK_ENABLED"] = "true"
+		data["WEBHOOK_PORT"] = strconv.Itoa(int(webhook.GetPort()))
+	}
+	if ha.GetSearXNG().IsEnabled() {
+		data["SEARXNG_URL"] = searxngURL
+	}
+	if ha.GetCamofox().IsEnabled() {
+		data["CAMOFOX_URL"] = camofoxURL
 	}
 
 	return &corev1.ConfigMap{

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -8,7 +8,6 @@ import (
 	agentsv1alpha1 "hermeum/hermes-agent-operator/api/v1alpha1"
 	"maps"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 
@@ -26,6 +25,10 @@ const (
 	hermesWorkspacePathSeparator = "--"
 	hermesDefaultProfile         = "default"
 	annotationDesiredSpecHash    = domain + "/desired-spec-hash"
+	// searxngURL is the in-pod URL the hermes-agent uses to reach the SearXNG sidecar.
+	searxngURL = "http://localhost:8080"
+	// camofoxURL is the in-pod URL the hermes-agent uses to reach the Camofox sidecar.
+	camofoxURL = "http://localhost:9377"
 )
 
 // hermesHealthCheckCommand reports the gateway state regardless of which
@@ -287,6 +290,8 @@ func buildInitContainerSecurityContext() *corev1.SecurityContext {
 // buildHermesContainer populates the StatefulSet with all resources driven by the hermes spec:
 // the main hermes-agent container (env, envFrom), init containers for config and workspace,
 // and volumes/PVCs for persistence, bootstrap config, and shared memory.
+//
+//nolint:gocyclo // inherent to the breadth of init containers and volume wiring
 func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSet) *appsv1.StatefulSet {
 	const (
 		hermesHomeVolume      = "hermes-data"
@@ -394,54 +399,16 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 			ContainerPort: apiServer.GetPort(),
 			Protocol:      corev1.ProtocolTCP,
 		})
-		apiKeyRef := &corev1.SecretKeySelector{
-			LocalObjectReference: corev1.LocalObjectReference{Name: ha.GetHermesName()},
-			Key:                  "API_SERVER_KEY",
-		}
-		if ref := apiServer.GetExistingSecret(); ref != nil {
-			apiKeyRef = ref
-		}
-		container.Env = append(container.Env, []corev1.EnvVar{
-			{
-				Name:      "API_SERVER_KEY",
-				ValueFrom: &corev1.EnvVarSource{SecretKeyRef: apiKeyRef},
-			},
-			{Name: "API_SERVER_ENABLED", Value: "true"},
-			// The default bind is 127.0.0.1, which is unreachable from outside
-			// the pod; bind all interfaces so the Service can route to it.
-			{Name: "API_SERVER_HOST", Value: "0.0.0.0"},
-			{Name: "API_SERVER_PORT", Value: strconv.Itoa(int(apiServer.GetPort()))},
-		}...)
-		if origins := apiServer.GetCORSOrigins(); len(origins) > 0 {
-			container.Env = append(container.Env, corev1.EnvVar{
-				Name:  "API_SERVER_CORS_ORIGINS",
-				Value: strings.Join(origins, ","),
-			})
-		}
 	}
 
 	// Webhook configuration
-	if ha.GetHermes().GetWebhook().IsEnabled() {
+	webhook := ha.GetHermes().GetWebhook()
+	if webhook.IsEnabled() {
 		container.Ports = append(container.Ports, corev1.ContainerPort{
-			Name:          ha.GetHermes().GetWebhook().GetPortName(),
-			ContainerPort: ha.GetHermes().GetWebhook().GetPort(),
+			Name:          webhook.GetPortName(),
+			ContainerPort: webhook.GetPort(),
 			Protocol:      corev1.ProtocolTCP,
 		})
-		secretRef := ha.GetHermes().GetWebhook().GetSecretRef()
-		if secretRef == nil {
-			secretRef = &corev1.SecretKeySelector{
-				LocalObjectReference: corev1.LocalObjectReference{Name: ha.GetHermesName()},
-				Key:                  "WEBHOOK_SECRET",
-			}
-		}
-		container.Env = append(container.Env, []corev1.EnvVar{
-			{
-				Name:      "WEBHOOK_SECRET",
-				ValueFrom: &corev1.EnvVarSource{SecretKeyRef: secretRef},
-			},
-			{Name: "WEBHOOK_ENABLED", Value: "true"},
-			{Name: "WEBHOOK_PORT", Value: strconv.Itoa(int(ha.GetHermes().GetWebhook().GetPort()))},
-		}...)
 	}
 
 	// persistence: existingClaim > enabled PVC > emptyDir fallback.
@@ -503,19 +470,31 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 	// ConfigMap keys use the format "profile.default.workspace.<path>" with "/" replaced by "--".
 	initContainers = append(initContainers, initContainer("init-workspace", buildWorkspaceScript(hermesDefaultProfile)))
 
-	// dotenv: init container writes the default profile .env from a Kubernetes ConfigMap and/or Secret.
-	if de := ha.GetHermes().GetWorkspace().GetDotEnv(); de != nil {
+	// dotenv: init container writes the default profile .env.
+	//
+	// Operator-managed env vars (API_SERVER_*, WEBHOOK_*, SEARXNG_URL,
+	// CAMOFOX_URL) are stored as keys in the Hermes ConfigMap and Secret, then
+	// mounted into the init container with Items filters so the existing
+	// `for f in .../*` loop dumps them as KEY=VALUE lines — the same mechanism
+	// as user workspace.dotEnv. Operator mounts come first so user dotEnv keys
+	// override on collision (user wins).
+	de := ha.GetHermes().GetWorkspace().GetDotEnv()
+	operatorItems := buildOperatorDotEnvItems(ha)
+	operatorSecretItems := buildOperatorDotEnvSecretItems(ha)
+	if de != nil || len(operatorItems) > 0 || len(operatorSecretItems) > 0 {
 		var mountPaths []string
 		var mounts []corev1.VolumeMount
 
-		if de.ConfigMapRef != nil {
-			const dotenvConfigMapVolume = "hermes-dotenv-configmap"
-			const dotenvConfigMapMount = "/hermes-dotenv-configmap"
+		// Operator-managed volumes first (user keys override on collision).
+		if len(operatorItems) > 0 {
+			const dotenvConfigMapVolume = "hermes-operator-dotenv-configmap"
+			const dotenvConfigMapMount = "/hermes-operator-dotenv-configmap"
 			volumes = append(volumes, corev1.Volume{
 				Name: dotenvConfigMapVolume,
 				VolumeSource: corev1.VolumeSource{
 					ConfigMap: &corev1.ConfigMapVolumeSource{
-						LocalObjectReference: corev1.LocalObjectReference{Name: de.ConfigMapRef.Name},
+						LocalObjectReference: corev1.LocalObjectReference{Name: ha.GetHermesName()},
+						Items:                operatorItems,
 					},
 				},
 			})
@@ -523,19 +502,52 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 			mountPaths = append(mountPaths, dotenvConfigMapMount)
 		}
 
-		if de.SecretRef != nil {
-			const dotenvVolume = "hermes-dotenv-secret"
-			const dotenvMount = "/hermes-dotenv-secret"
+		if len(operatorSecretItems) > 0 {
+			const dotenvVolume = "hermes-operator-dotenv-secret"
+			const dotenvMount = "/hermes-operator-dotenv-secret"
 			volumes = append(volumes, corev1.Volume{
 				Name: dotenvVolume,
 				VolumeSource: corev1.VolumeSource{
 					Secret: &corev1.SecretVolumeSource{
-						SecretName: de.SecretRef.Name,
+						SecretName: ha.GetHermesName(),
+						Items:      operatorSecretItems,
 					},
 				},
 			})
 			mounts = append(mounts, corev1.VolumeMount{Name: dotenvVolume, MountPath: dotenvMount, ReadOnly: true})
 			mountPaths = append(mountPaths, dotenvMount)
+		}
+
+		if de != nil {
+			if de.ConfigMapRef != nil {
+				const dotenvConfigMapVolume = "hermes-dotenv-configmap"
+				const dotenvConfigMapMount = "/hermes-dotenv-configmap"
+				volumes = append(volumes, corev1.Volume{
+					Name: dotenvConfigMapVolume,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: de.ConfigMapRef.Name},
+						},
+					},
+				})
+				mounts = append(mounts, corev1.VolumeMount{Name: dotenvConfigMapVolume, MountPath: dotenvConfigMapMount, ReadOnly: true})
+				mountPaths = append(mountPaths, dotenvConfigMapMount)
+			}
+
+			if de.SecretRef != nil {
+				const dotenvVolume = "hermes-dotenv-secret"
+				const dotenvMount = "/hermes-dotenv-secret"
+				volumes = append(volumes, corev1.Volume{
+					Name: dotenvVolume,
+					VolumeSource: corev1.VolumeSource{
+						Secret: &corev1.SecretVolumeSource{
+							SecretName: de.SecretRef.Name,
+						},
+					},
+				})
+				mounts = append(mounts, corev1.VolumeMount{Name: dotenvVolume, MountPath: dotenvMount, ReadOnly: true})
+				mountPaths = append(mountPaths, dotenvMount)
+			}
 		}
 
 		ic := initContainer("init-dotenv", buildDotEnvScript(hermesDefaultProfile, mountPaths...))
@@ -599,10 +611,38 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		{
 			var s strings.Builder
 			ic := initContainer("init-profiles-dotenv", "")
+			// SEARXNG_URL / CAMOFOX_URL point at shared sidecars and are written
+			// to every named profile's .env. API_SERVER_* / WEBHOOK_* are
+			// intentionally excluded — they belong to the default profile's
+			// gateway.
+			sidecarItems := buildProfileSidecarDotEnvItems(ha)
 			for _, name := range names {
-				if de := profiles[name].Workspace.GetDotEnv(); de != nil {
-					var mountPaths []string
+				de := profiles[name].Workspace.GetDotEnv()
+				if de == nil && len(sidecarItems) == 0 {
+					continue
+				}
+				var mountPaths []string
 
+				// Operator sidecar keys first (user keys override on collision).
+				if len(sidecarItems) > 0 {
+					volName := "hermes-operator-dotenv-profile-" + name
+					mountPath := "/hermes-operator-dotenv-profile-" + name
+					volumes = append(volumes, corev1.Volume{
+						Name: volName,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: ha.GetHermesName()},
+								Items:                sidecarItems,
+							},
+						},
+					})
+					ic.VolumeMounts = append(ic.VolumeMounts, corev1.VolumeMount{
+						Name: volName, MountPath: mountPath, ReadOnly: true,
+					})
+					mountPaths = append(mountPaths, mountPath)
+				}
+
+				if de != nil {
 					if de.ConfigMapRef != nil {
 						volName := "hermes-dotenv-configmap-profile-" + name
 						mountPath := "/hermes-dotenv-configmap-profile-" + name
@@ -634,9 +674,9 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 						})
 						mountPaths = append(mountPaths, mountPath)
 					}
-
-					s.WriteString(buildDotEnvScript(name, mountPaths...))
 				}
+
+				s.WriteString(buildDotEnvScript(name, mountPaths...))
 			}
 			if s.Len() > 0 {
 				ic.Args = []string{s.String()}
@@ -754,7 +794,6 @@ func buildSearXNGContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulS
 		searxngBootstrapMount  = "/bootstrap-searxng"
 		searxngCacheVolume     = "searxng-cache"
 		searxngCacheMount      = "/var/cache/searxng"
-		searxngURL             = "http://localhost:8080"
 	)
 
 	// Inject SEARXNG_URL into the hermes-agent container env so that the web_search tool can find it.
@@ -875,7 +914,6 @@ func buildCamofoxContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulS
 		camofoxContainerName = "camofox"
 		camofoxDataVolume    = "camofox-data"
 		camofoxDataMount     = "/root/.camofox"
-		camofoxURL           = "http://localhost:9377"
 	)
 
 	// Inject CAMOFOX_URL into the hermes-agent container env so that the browser tool can find it.
@@ -1258,6 +1296,65 @@ func buildDotEnvScript(profile string, mountPaths ...string) string {
 %s} > "$(hermes config env-path -p %q)"
 echo "Generated .env for profile %s"
 `, body.String(), profile, profile)
+}
+
+// buildOperatorDotEnvItems returns the ConfigMap Items filter for operator-managed
+// non-secret env vars written to the default profile's .env: API_SERVER_ENABLED,
+// API_SERVER_HOST, API_SERVER_PORT, optional API_SERVER_CORS_ORIGINS,
+// WEBHOOK_ENABLED, WEBHOOK_PORT, SEARXNG_URL, CAMOFOX_URL.
+func buildOperatorDotEnvItems(ha *agentsv1alpha1.HermesAgent) []corev1.KeyToPath {
+	var items []corev1.KeyToPath
+	if apiServer := ha.GetHermes().GetAPIServer(); apiServer.IsEnabled() {
+		items = append(items,
+			corev1.KeyToPath{Key: "API_SERVER_ENABLED", Path: "API_SERVER_ENABLED"},
+			corev1.KeyToPath{Key: "API_SERVER_HOST", Path: "API_SERVER_HOST"},
+			corev1.KeyToPath{Key: "API_SERVER_PORT", Path: "API_SERVER_PORT"},
+		)
+		if origins := apiServer.GetCORSOrigins(); len(origins) > 0 {
+			items = append(items, corev1.KeyToPath{Key: "API_SERVER_CORS_ORIGINS", Path: "API_SERVER_CORS_ORIGINS"})
+		}
+	}
+	if webhook := ha.GetHermes().GetWebhook(); webhook.IsEnabled() {
+		items = append(items,
+			corev1.KeyToPath{Key: "WEBHOOK_ENABLED", Path: "WEBHOOK_ENABLED"},
+			corev1.KeyToPath{Key: "WEBHOOK_PORT", Path: "WEBHOOK_PORT"},
+		)
+	}
+	if ha.GetSearXNG().IsEnabled() {
+		items = append(items, corev1.KeyToPath{Key: "SEARXNG_URL", Path: "SEARXNG_URL"})
+	}
+	if ha.GetCamofox().IsEnabled() {
+		items = append(items, corev1.KeyToPath{Key: "CAMOFOX_URL", Path: "CAMOFOX_URL"})
+	}
+	return items
+}
+
+// buildOperatorDotEnvSecretItems returns the Secret Items filter for
+// operator-managed secret env vars written to the default profile's .env:
+// API_SERVER_KEY and/or WEBHOOK_SECRET.
+func buildOperatorDotEnvSecretItems(ha *agentsv1alpha1.HermesAgent) []corev1.KeyToPath {
+	var items []corev1.KeyToPath
+	if ha.GetHermes().GetAPIServer().IsEnabled() {
+		items = append(items, corev1.KeyToPath{Key: "API_SERVER_KEY", Path: "API_SERVER_KEY"})
+	}
+	if ha.GetHermes().GetWebhook().IsEnabled() {
+		items = append(items, corev1.KeyToPath{Key: "WEBHOOK_SECRET", Path: "WEBHOOK_SECRET"})
+	}
+	return items
+}
+
+// buildProfileSidecarDotEnvItems returns the ConfigMap Items filter for the
+// shared sidecar URLs written to every named profile's .env. API_SERVER_* and
+// WEBHOOK_* are excluded — they belong to the default profile's gateway.
+func buildProfileSidecarDotEnvItems(ha *agentsv1alpha1.HermesAgent) []corev1.KeyToPath {
+	var items []corev1.KeyToPath
+	if ha.GetSearXNG().IsEnabled() {
+		items = append(items, corev1.KeyToPath{Key: "SEARXNG_URL", Path: "SEARXNG_URL"})
+	}
+	if ha.GetCamofox().IsEnabled() {
+		items = append(items, corev1.KeyToPath{Key: "CAMOFOX_URL", Path: "CAMOFOX_URL"})
+	}
+	return items
 }
 
 func sortedProfileNames(profiles map[string]agentsv1alpha1.HermesProfile) []string {

--- a/internal/usecase/hermesagent_statefulset_test.go
+++ b/internal/usecase/hermesagent_statefulset_test.go
@@ -6,9 +6,13 @@ import (
 
 	agentsv1alpha1 "hermeum/hermes-agent-operator/api/v1alpha1"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
+
+const testTrue = "true"
 
 func minimalHA() *agentsv1alpha1.HermesAgent {
 	return &agentsv1alpha1.HermesAgent{
@@ -62,7 +66,7 @@ func TestDesiredSpecHash(t *testing.T) {
 		ha := minimalHA()
 		sts := buildStatefulSet(ha)
 		h1 := desiredSpecHash(sts)
-		sts.Labels["k8s-injected"] = "true"
+		sts.Labels["k8s-injected"] = testTrue
 		if desiredSpecHash(sts) != h1 {
 			t.Error("hash must not change when only ObjectMeta differs")
 		}
@@ -89,12 +93,12 @@ func TestBuildStatefulSetPodAnnotations(t *testing.T) {
 
 	t.Run("user annotations are merged in", func(t *testing.T) {
 		ha := minimalHA()
-		ha.Spec.PodAnnotations = map[string]string{"rotatedAt": "2026-07-06T12:00:00Z", "prometheus.io/scrape": "true"}
+		ha.Spec.PodAnnotations = map[string]string{"rotatedAt": "2026-07-06T12:00:00Z", "prometheus.io/scrape": testTrue}
 		sts := buildStatefulSet(ha)
 		if sts.Spec.Template.Annotations["rotatedAt"] != "2026-07-06T12:00:00Z" {
 			t.Error("expected rotatedAt annotation to be present")
 		}
-		if sts.Spec.Template.Annotations["prometheus.io/scrape"] != "true" {
+		if sts.Spec.Template.Annotations["prometheus.io/scrape"] != testTrue {
 			t.Error("expected prometheus.io/scrape annotation to be present")
 		}
 		if _, ok := sts.Spec.Template.Annotations[domain+"/config-hash"]; !ok {
@@ -565,4 +569,393 @@ func TestBuildCronsScript(t *testing.T) {
 			t.Errorf("expected manifest path profiles/coder/crons, got:\n%s", got)
 		}
 	})
+}
+
+// findInitContainer returns a pointer to the init container with the given
+// name, or nil if none exists in the StatefulSet.
+func findInitContainer(sts *appsv1.StatefulSet, name string) *corev1.Container {
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		if sts.Spec.Template.Spec.InitContainers[i].Name == name {
+			return &sts.Spec.Template.Spec.InitContainers[i]
+		}
+	}
+	return nil
+}
+
+// findHermesContainer returns a pointer to the hermes-agent container in the
+// StatefulSet, or nil if none exists.
+func findHermesContainer(sts *appsv1.StatefulSet) *corev1.Container {
+	for i := range sts.Spec.Template.Spec.Containers {
+		if sts.Spec.Template.Spec.Containers[i].Name == hermesContainerName {
+			return &sts.Spec.Template.Spec.Containers[i]
+		}
+	}
+	return nil
+}
+
+// hasEnvVar reports whether the given env var name is present in the slice.
+func hasEnvVar(envs []corev1.EnvVar, name string) bool {
+	for _, e := range envs {
+		if e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// hasVolumeMount reports whether a volume mount with the given name exists.
+func hasVolumeMount(mounts []corev1.VolumeMount, name string) bool {
+	for _, m := range mounts {
+		if m.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestOperatorDotEnvAPIServer(t *testing.T) {
+	t.Run("enabled: ConfigMap has operator keys, init-dotenv mounts them", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+			Config: &agentsv1alpha1.HermesConfig{
+				APIServer: &agentsv1alpha1.HermesAPIServer{Enabled: true},
+			},
+		}
+
+		// ConfigMap must contain the operator env-var keys.
+		cm, err := buildHermesConfigMap(ha)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, key := range []string{"API_SERVER_ENABLED", "API_SERVER_HOST", "API_SERVER_PORT"} {
+			if _, ok := cm.Data[key]; !ok {
+				t.Errorf("expected %q in ConfigMap data", key)
+			}
+		}
+		if cm.Data["API_SERVER_ENABLED"] != testTrue {
+			t.Errorf("expected API_SERVER_ENABLED=true, got %q", cm.Data["API_SERVER_ENABLED"])
+		}
+		if cm.Data["API_SERVER_HOST"] != "0.0.0.0" {
+			t.Errorf("expected API_SERVER_HOST=0.0.0.0, got %q", cm.Data["API_SERVER_HOST"])
+		}
+
+		// init-dotenv must exist and mount the operator ConfigMap and Secret.
+		sts := buildStatefulSet(ha)
+		ic := findInitContainer(sts, "init-dotenv")
+		if ic == nil {
+			t.Fatal("expected init-dotenv init container")
+		}
+		if !hasVolumeMount(ic.VolumeMounts, "hermes-operator-dotenv-configmap") {
+			t.Error("expected hermes-operator-dotenv-configmap volume mount on init-dotenv")
+		}
+		if !hasVolumeMount(ic.VolumeMounts, "hermes-operator-dotenv-secret") {
+			t.Error("expected hermes-operator-dotenv-secret volume mount on init-dotenv")
+		}
+		// The script must iterate the operator mount paths.
+		if !strings.Contains(ic.Args[0], "/hermes-operator-dotenv-configmap") {
+			t.Errorf("expected operator configmap mount path in script, got:\n%s", ic.Args[0])
+		}
+		if !strings.Contains(ic.Args[0], "/hermes-operator-dotenv-secret") {
+			t.Errorf("expected operator secret mount path in script, got:\n%s", ic.Args[0])
+		}
+
+		// API_SERVER_* env vars are injected via .env, not container env.
+		c := findHermesContainer(sts)
+		if c == nil {
+			t.Fatal("expected hermes-agent container")
+		}
+		for _, name := range []string{"API_SERVER_ENABLED", "API_SERVER_HOST", "API_SERVER_PORT", "API_SERVER_KEY"} {
+			if hasEnvVar(c.Env, name) {
+				t.Errorf("expected %q absent from hermes-agent container Env (injected via .env)", name)
+			}
+		}
+	})
+
+	t.Run("corsOrigins in ConfigMap when set", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+			Config: &agentsv1alpha1.HermesConfig{
+				APIServer: &agentsv1alpha1.HermesAPIServer{
+					Enabled:     true,
+					CORSOrigins: []string{"https://a.example", "https://b.example"},
+				},
+			},
+		}
+		cm, err := buildHermesConfigMap(ha)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cm.Data["API_SERVER_CORS_ORIGINS"] != "https://a.example,https://b.example" {
+			t.Errorf("expected CORS origins in ConfigMap, got %q", cm.Data["API_SERVER_CORS_ORIGINS"])
+		}
+	})
+
+	t.Run("custom port in ConfigMap", func(t *testing.T) {
+		ha := minimalHA()
+		port := int32(9000)
+		ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+			Config: &agentsv1alpha1.HermesConfig{
+				APIServer: &agentsv1alpha1.HermesAPIServer{Enabled: true, Port: &port},
+			},
+		}
+		cm, err := buildHermesConfigMap(ha)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cm.Data["API_SERVER_PORT"] != "9000" {
+			t.Errorf("expected API_SERVER_PORT=9000, got %q", cm.Data["API_SERVER_PORT"])
+		}
+	})
+
+	t.Run("disabled: no operator keys in ConfigMap, no init-dotenv", func(t *testing.T) {
+		ha := minimalHA()
+		cm, err := buildHermesConfigMap(ha)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, key := range []string{"API_SERVER_ENABLED", "API_SERVER_HOST", "API_SERVER_PORT"} {
+			if _, ok := cm.Data[key]; ok {
+				t.Errorf("expected %q absent from ConfigMap when apiServer disabled", key)
+			}
+		}
+		sts := buildStatefulSet(ha)
+		if ic := findInitContainer(sts, "init-dotenv"); ic != nil {
+			t.Errorf("expected no init-dotenv when nothing enabled, got: %v", ic)
+		}
+	})
+}
+
+func TestOperatorDotEnvWebhook(t *testing.T) {
+	ha := minimalHA()
+	ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+		Config: &agentsv1alpha1.HermesConfig{
+			Webhook: &agentsv1alpha1.HermesWebhook{Enabled: true},
+		},
+	}
+
+	cm, err := buildHermesConfigMap(ha)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cm.Data["WEBHOOK_ENABLED"] != testTrue {
+		t.Errorf("expected WEBHOOK_ENABLED=true, got %q", cm.Data["WEBHOOK_ENABLED"])
+	}
+	if cm.Data["WEBHOOK_PORT"] != "8644" {
+		t.Errorf("expected WEBHOOK_PORT=8644, got %q", cm.Data["WEBHOOK_PORT"])
+	}
+
+	sts := buildStatefulSet(ha)
+	ic := findInitContainer(sts, "init-dotenv")
+	if ic == nil {
+		t.Fatal("expected init-dotenv init container")
+	}
+	if !hasVolumeMount(ic.VolumeMounts, "hermes-operator-dotenv-secret") {
+		t.Error("expected hermes-operator-dotenv-secret volume mount on init-dotenv")
+	}
+
+	// WEBHOOK_* env vars are injected via .env, not container env.
+	c := findHermesContainer(sts)
+	if c == nil {
+		t.Fatal("expected hermes-agent container")
+	}
+	for _, name := range []string{"WEBHOOK_ENABLED", "WEBHOOK_PORT", "WEBHOOK_SECRET"} {
+		if hasEnvVar(c.Env, name) {
+			t.Errorf("expected %q absent from hermes-agent container Env (injected via .env)", name)
+		}
+	}
+}
+
+func TestOperatorDotEnvSidecars(t *testing.T) {
+	t.Run("searxng: SEARXNG_URL in ConfigMap and init-dotenv", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.SearXNG = &agentsv1alpha1.SearXNG{Enabled: true}
+
+		cm, err := buildHermesConfigMap(ha)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cm.Data["SEARXNG_URL"] != "http://localhost:8080" {
+			t.Errorf("expected SEARXNG_URL in ConfigMap, got %q", cm.Data["SEARXNG_URL"])
+		}
+
+		sts := buildStatefulSet(ha)
+		ic := findInitContainer(sts, "init-dotenv")
+		if ic == nil {
+			t.Fatal("expected init-dotenv init container")
+		}
+		if !strings.Contains(ic.Args[0], "/hermes-operator-dotenv-configmap") {
+			t.Errorf("expected operator configmap mount path in script, got:\n%s", ic.Args[0])
+		}
+
+		c := findHermesContainer(sts)
+		if c == nil {
+			t.Fatal("expected hermes-agent container")
+		}
+		if !hasEnvVar(c.Env, "SEARXNG_URL") {
+			t.Error("expected SEARXNG_URL in hermes-agent container Env")
+		}
+	})
+
+	t.Run("camofox: CAMOFOX_URL in ConfigMap and init-dotenv", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.Camofox = &agentsv1alpha1.Camofox{Enabled: true}
+
+		cm, err := buildHermesConfigMap(ha)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if cm.Data["CAMOFOX_URL"] != "http://localhost:9377" {
+			t.Errorf("expected CAMOFOX_URL in ConfigMap, got %q", cm.Data["CAMOFOX_URL"])
+		}
+
+		sts := buildStatefulSet(ha)
+		ic := findInitContainer(sts, "init-dotenv")
+		if ic == nil {
+			t.Fatal("expected init-dotenv init container")
+		}
+		if !strings.Contains(ic.Args[0], "/hermes-operator-dotenv-configmap") {
+			t.Errorf("expected operator configmap mount path in script, got:\n%s", ic.Args[0])
+		}
+
+		c := findHermesContainer(sts)
+		if c == nil {
+			t.Fatal("expected hermes-agent container")
+		}
+		if !hasEnvVar(c.Env, "CAMOFOX_URL") {
+			t.Error("expected CAMOFOX_URL in hermes-agent container Env")
+		}
+	})
+}
+
+func TestOperatorDotEnvMultiplex(t *testing.T) {
+	t.Run("named profiles get SEARXNG_URL/CAMOFOX_URL, not API_SERVER_*", func(t *testing.T) {
+		ha := minimalHA()
+		ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+			Config: &agentsv1alpha1.HermesConfig{
+				APIServer: &agentsv1alpha1.HermesAPIServer{Enabled: true},
+			},
+			Profiles: map[string]agentsv1alpha1.HermesProfile{
+				"coder":  {},
+				"writer": {},
+			},
+		}
+		ha.Spec.SearXNG = &agentsv1alpha1.SearXNG{Enabled: true}
+		ha.Spec.Camofox = &agentsv1alpha1.Camofox{Enabled: true}
+
+		sts := buildStatefulSet(ha)
+
+		// Default profile: operator ConfigMap + Secret mounted.
+		defIC := findInitContainer(sts, "init-dotenv")
+		if defIC == nil {
+			t.Fatal("expected init-dotenv")
+		}
+		if !hasVolumeMount(defIC.VolumeMounts, "hermes-operator-dotenv-configmap") {
+			t.Error("expected operator configmap mount on default init-dotenv")
+		}
+		if !hasVolumeMount(defIC.VolumeMounts, "hermes-operator-dotenv-secret") {
+			t.Error("expected operator secret mount on default init-dotenv")
+		}
+
+		// Named profiles: only sidecar URLs, no API_SERVER_*/WEBHOOK_*.
+		profIC := findInitContainer(sts, "init-profiles-dotenv")
+		if profIC == nil {
+			t.Fatal("expected init-profiles-dotenv")
+		}
+		profScript := profIC.Args[0]
+		if !strings.Contains(profScript, "hermes-operator-dotenv-profile-coder") {
+			t.Errorf("expected operator dotenv mount for coder profile, got:\n%s", profScript)
+		}
+		if !strings.Contains(profScript, "hermes-operator-dotenv-profile-writer") {
+			t.Errorf("expected operator dotenv mount for writer profile, got:\n%s", profScript)
+		}
+		// Must NOT have API_SERVER or WEBHOOK in named-profile dotenv.
+		if strings.Contains(profScript, "API_SERVER") {
+			t.Errorf("API_SERVER_* must not appear in named-profile dotenv, got:\n%s", profScript)
+		}
+		if strings.Contains(profScript, "WEBHOOK") {
+			t.Errorf("WEBHOOK_* must not appear in named-profile dotenv, got:\n%s", profScript)
+		}
+		// Each named profile gets its own .env block.
+		if strings.Count(profScript, `hermes config env-path -p "coder"`) != 1 {
+			t.Errorf("expected one coder dotenv block, got:\n%s", profScript)
+		}
+		if strings.Count(profScript, `hermes config env-path -p "writer"`) != 1 {
+			t.Errorf("expected one writer dotenv block, got:\n%s", profScript)
+		}
+	})
+}
+
+func TestOperatorDotEnvCollision(t *testing.T) {
+	// User workspace.dotEnv keys override operator keys (user wins).
+	ha := minimalHA()
+	ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+		Config: &agentsv1alpha1.HermesConfig{
+			APIServer: &agentsv1alpha1.HermesAPIServer{Enabled: true},
+		},
+		Workspace: &agentsv1alpha1.HermesWorkspace{
+			DotEnv: &agentsv1alpha1.HermesDotEnv{
+				SecretRef: &corev1.LocalObjectReference{Name: "my-env"},
+			},
+		},
+	}
+	sts := buildStatefulSet(ha)
+	ic := findInitContainer(sts, "init-dotenv")
+	if ic == nil {
+		t.Fatal("expected init-dotenv")
+	}
+	script := ic.Args[0]
+	// Operator mount path must come before user mount path.
+	operatorIdx := strings.Index(script, "/hermes-operator-dotenv-configmap")
+	userIdx := strings.Index(script, "/hermes-dotenv-secret")
+	if operatorIdx < 0 || userIdx < 0 {
+		t.Fatalf("expected both operator and user mount paths in script, got:\n%s", script)
+	}
+	if operatorIdx >= userIdx {
+		t.Errorf("expected operator mount before user mount; operator at %d, user at %d in:\n%s",
+			operatorIdx, userIdx, script)
+	}
+}
+
+func TestOperatorDotEnvOrdering(t *testing.T) {
+	ha := minimalHA()
+	ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+		Config: &agentsv1alpha1.HermesConfig{
+			APIServer: &agentsv1alpha1.HermesAPIServer{Enabled: true},
+		},
+	}
+	sts := buildStatefulSet(ha)
+	var workspaceIdx, dotenvIdx = -1, -1
+	for i, c := range sts.Spec.Template.Spec.InitContainers {
+		switch c.Name {
+		case "init-workspace":
+			workspaceIdx = i
+		case "init-dotenv":
+			dotenvIdx = i
+		}
+	}
+	if workspaceIdx < 0 {
+		t.Fatal("init-workspace not found")
+	}
+	if dotenvIdx < 0 {
+		t.Fatal("init-dotenv not found")
+	}
+	if dotenvIdx <= workspaceIdx {
+		t.Errorf("expected init-dotenv (idx %d) after init-workspace (idx %d)", dotenvIdx, workspaceIdx)
+	}
+}
+
+func TestOperatorDotEnvUserDotEnvAlone(t *testing.T) {
+	// User dotEnv without any operator features still emits init-dotenv.
+	ha := minimalHA()
+	ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+		Workspace: &agentsv1alpha1.HermesWorkspace{
+			DotEnv: &agentsv1alpha1.HermesDotEnv{
+				SecretRef: &corev1.LocalObjectReference{Name: "my-env"},
+			},
+		},
+	}
+	sts := buildStatefulSet(ha)
+	if findInitContainer(sts, "init-dotenv") == nil {
+		t.Error("expected init-dotenv when user dotEnv is set")
+	}
 }


### PR DESCRIPTION
## Problem

In multiplex mode (when named profiles are declared), the Hermes gateway sources `.env` instead of the process environment. The operator was setting `API_SERVER_*`, `WEBHOOK_*`, `SEARXNG_URL`, and `CAMOFOX_URL` as container env vars, which the gateway ignored — so the API server never started.

## Fix

Store operator-managed env vars as keys in the existing Hermes ConfigMap (non-secret) and Secret (secret), then mount specific keys into the `init-dotenv` / `init-profiles-dotenv` init containers via `Items` filters. The existing `for f in .../*` loop dumps them as `KEY=VALUE` lines into `.env` — the same mechanism as user `workspace.dotEnv`.

### Changes

- **`hermesagent_hermes_configmap.go`**: `buildHermesConfigMap` adds operator env-var keys (`API_SERVER_ENABLED`, `API_SERVER_HOST`, `API_SERVER_PORT`, `API_SERVER_CORS_ORIGINS`, `WEBHOOK_ENABLED`, `WEBHOOK_PORT`, `SEARXNG_URL`, `CAMOFOX_URL`) when the respective features are enabled.

- **`hermesagent_statefulset.go`**:
  - Removed `container.Env` appends for `API_SERVER_*` / `WEBHOOK_*` (container **Ports** kept). These are now injected via `.env` only.
  - `init-dotenv` mounts operator ConfigMap + Secret with `Items` filters (operator mounts first; user `workspace.dotEnv` keys override on collision — user wins).
  - `init-profiles-dotenv` mounts `SEARXNG_URL` / `CAMOFOX_URL` per named profile (`API_SERVER_*` / `WEBHOOK_*` excluded — default-profile gateway only).
  - Hoisted `searxngURL` / `camofoxURL` to package-level constants.
  - Added `buildOperatorDotEnvItems`, `buildOperatorDotEnvSecretItems`, `buildProfileSidecarDotEnvItems` helpers (`[]KeyToPath` only, matching the existing sidecar pattern).

- **`hermesagent_statefulset_test.go`**: Tests covering ConfigMap keys, init-dotenv mounts, container env absence, multiplex (named profiles get sidecar URLs only), collision precedence, and init ordering.

### Notes

- `SEARXNG_URL` / `CAMOFOX_URL` remain as container env vars (injected by the sidecar builders) and are also written to `.env`.
- `existingSecret` / `secretRef` resolution for `API_SERVER_KEY` / `WEBHOOK_SECRET` is not carried into the dotenv mount — the operator-managed `<agent>-hermes` Secret is always used.

## Test plan

- [x] `make lint-fix` — 0 issues
- [x] `make test` / `go test ./...` — all packages pass
- [x] E2E: deploy a multi-profile HermesAgent with `apiServer.enabled: true` and verify the API server starts on port 8642