### PR TITLE
docs: add Telegram bot example with online/offline status indicator

### DIFF
--- a/skills/hermes-agent-operator/examples/telegram_bot.yaml
+++ b/skills/hermes-agent-operator/examples/telegram_bot.yaml
@@ -1,0 +1,37 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: telegram-bot-secrets
+stringData:
+  OLLAMA_API_KEY: ""
+  TELEGRAM_BOT_TOKEN: ""
+  TELEGRAM_ALLOWED_USERS: ""
+---
+apiVersion: agents.hermeum.app/v1alpha1
+kind: HermesAgent
+metadata:
+  name: telegram-bot
+spec:
+  hermes:
+    config:
+      raw:
+        model:
+          base_url: https://ollama.com/v1
+          default: glm-5.2
+          provider: ollama-cloud
+        # Telegram gateway configuration.
+        # Env vars (TELEGRAM_BOT_TOKEN, TELEGRAM_ALLOWED_USERS) are injected
+        # via the .env Secret referenced in workspace.dotEnv.secretRef below.
+        gateway:
+          platforms:
+            telegram:
+              extra:
+                # Show Online/Offline in the bot's short description.
+                status_indicator: true
+                # Optional custom strings (defaults: "Online" / "Offline"):
+                status_online: "🟢 Online"
+                status_offline: "🔴 Offline"
+    workspace:
+      dotEnv:
+        secretRef:
+          name: telegram-bot-secrets


### PR DESCRIPTION
## Summary
- Add a new example manifest `telegram_bot.yaml` demonstrating Telegram gateway integration
- Includes a Secret with `TELEGRAM_BOT_TOKEN` and `TELEGRAM_ALLOWED_USERS` env vars, wired via `workspace.dotEnv.secretRef`
- Configures `gateway.platforms.telegram.extra.status_indicator` with custom `status_online` / `status_offline` strings for the bot's short description
- Model set to `glm-5.2` with `ollama-cloud` provider

## Docs reference
https://hermes-agent.nousresearch.com/docs/user-guide/messaging/telegram#step-5-configure-hermes

## Test plan
- [x] Apply the manifest against a cluster running the hermes-agent-operator
- [x] Verify the agent pod starts and the gateway connects to Telegram
- [x] Confirm the bot's short description shows the Online status string