### PR TITLE
refactor: consolidate operator-managed init containers

### DIFF
--- a/api/v1alpha1/hermesagent_types.go
+++ b/api/v1alpha1/hermesagent_types.go
@@ -638,7 +638,9 @@ type Hermes struct {
 	// +kubebuilder:validation:MaxItems=10
 	InitScripts []HermesInitScript `json:"initScripts,omitempty"`
 	// profiles is a map of named Hermes profiles to create and configure.
-	// Each profile is set up via dedicated init containers after the default profile.
+	// Each profile is set up via its own init-profile-<name> init container,
+	// which runs after the consolidated init-hermes container that configures
+	// the default profile.
 	// +optional
 	Profiles map[string]HermesProfile `json:"profiles,omitempty"`
 }
@@ -1326,7 +1328,7 @@ type HermesAgentSpec struct {
 	Networking *Networking `json:"networking,omitempty"`
 
 	// InitContainers is a list of additional init containers to run before the main container.
-	// They run after the operator-managed init-config and init-skills containers.
+	// They run after the operator-managed init-hermes and init-profile-<name> containers.
 	// +kubebuilder:validation:MaxItems=10
 	// +optional
 	InitContainers []corev1.Container `json:"initContainers,omitempty"`

--- a/config/crd/bases/agents.hermeum.app_hermesagents.yaml
+++ b/config/crd/bases/agents.hermeum.app_hermesagents.yaml
@@ -3046,6 +3046,9 @@ spec:
                                     configMapRef references a Kubernetes ConfigMap whose keys and values are
                                     written as KEY=VALUE lines to $HERMES_HOME/.env. See HermesDotEnv for
                                     the full precedence order on key collisions.
+
+                                    Deprecated: Use configMapRefs for new fields; singular forms will be
+                                    removed in the v1 type.
                                   properties:
                                     name:
                                       default: ""
@@ -3088,6 +3091,9 @@ spec:
                                     written as KEY=VALUE lines to $HERMES_HOME/.env. Secrets override
                                     ConfigMap keys of the same name. See HermesDotEnv for the full
                                     precedence order on key collisions.
+
+                                    Deprecated: Use secretRefs for new fields; singular forms will be
+                                    removed in the v1 type.
                                   properties:
                                     name:
                                       default: ""
@@ -3142,7 +3148,9 @@ spec:
                       type: object
                     description: |-
                       profiles is a map of named Hermes profiles to create and configure.
-                      Each profile is set up via dedicated init containers after the default profile.
+                      Each profile is set up via its own init-profile-<name> init container,
+                      which runs after the consolidated init-hermes container that configures
+                      the default profile.
                     type: object
                   resources:
                     description: resources overrides the resource requests and limits
@@ -3277,6 +3285,9 @@ spec:
                               configMapRef references a Kubernetes ConfigMap whose keys and values are
                               written as KEY=VALUE lines to $HERMES_HOME/.env. See HermesDotEnv for
                               the full precedence order on key collisions.
+
+                              Deprecated: Use configMapRefs for new fields; singular forms will be
+                              removed in the v1 type.
                             properties:
                               name:
                                 default: ""
@@ -3319,6 +3330,9 @@ spec:
                               written as KEY=VALUE lines to $HERMES_HOME/.env. Secrets override
                               ConfigMap keys of the same name. See HermesDotEnv for the full
                               precedence order on key collisions.
+
+                              Deprecated: Use secretRefs for new fields; singular forms will be
+                              removed in the v1 type.
                             properties:
                               name:
                                 default: ""
@@ -3374,7 +3388,7 @@ spec:
               initContainers:
                 description: |-
                   InitContainers is a list of additional init containers to run before the main container.
-                  They run after the operator-managed init-config and init-skills containers.
+                  They run after the operator-managed init-hermes and init-profile-<name> containers.
                 items:
                   description: A single application container that you want to run
                     within a pod.

--- a/dist/chart/templates/crd/hermesagents.agents.hermeum.app.yaml
+++ b/dist/chart/templates/crd/hermesagents.agents.hermeum.app.yaml
@@ -3038,15 +3038,20 @@ spec:
                           properties:
                             dotEnv:
                               description: |-
-                                dotEnv generates a $HERMES_HOME/.env file from a Kubernetes Secret
-                                and/or ConfigMap. Each key in the referenced Secret/ConfigMap becomes a
-                                KEY=VALUE line in the file. If both are set, Secret keys override
-                                ConfigMap keys of the same name.
+                                dotEnv generates a $HERMES_HOME/.env file from Kubernetes Secrets
+                                and/or ConfigMaps. Each key in the referenced Secret/ConfigMap becomes a
+                                KEY=VALUE line in the file. Both singular (secretRef/configMapRef) and
+                                plural (secretRefs/configMapRefs) forms are supported and may be
+                                combined; see HermesDotEnv for the precedence order on key collisions.
                               properties:
                                 configMapRef:
                                   description: |-
                                     configMapRef references a Kubernetes ConfigMap whose keys and values are
-                                    written as KEY=VALUE lines to $HERMES_HOME/.env.
+                                    written as KEY=VALUE lines to $HERMES_HOME/.env. See HermesDotEnv for
+                                    the full precedence order on key collisions.
+
+                                    Deprecated: Use configMapRefs for new fields; singular forms will be
+                                    removed in the v1 type.
                                   properties:
                                     name:
                                       default: ""
@@ -3059,11 +3064,39 @@ spec:
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                configMapRefs:
+                                  description: |-
+                                    configMapRefs references Kubernetes ConfigMaps whose keys and values
+                                    are written as KEY=VALUE lines to $HERMES_HOME/.env. Entries are
+                                    applied in order; later entries override earlier ones on key
+                                    collision. See HermesDotEnv for the full precedence order.
+                                  items:
+                                    description: |-
+                                      LocalObjectReference contains enough information to let you locate the
+                                      referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  maxItems: 64
+                                  type: array
                                 secretRef:
                                   description: |-
                                     secretRef references a Kubernetes Secret whose keys and values are
-                                    written as KEY=VALUE lines to $HERMES_HOME/.env. If configMapRef is
-                                    also set, these values take precedence on key collisions.
+                                    written as KEY=VALUE lines to $HERMES_HOME/.env. Secrets override
+                                    ConfigMap keys of the same name. See HermesDotEnv for the full
+                                    precedence order on key collisions.
+
+                                    Deprecated: Use secretRefs for new fields; singular forms will be
+                                    removed in the v1 type.
                                   properties:
                                     name:
                                       default: ""
@@ -3076,11 +3109,37 @@ spec:
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                secretRefs:
+                                  description: |-
+                                    secretRefs references Kubernetes Secrets whose keys and values are
+                                    written as KEY=VALUE lines to $HERMES_HOME/.env. Entries are applied
+                                    in order; later entries override earlier ones on key collision, and
+                                    all Secrets override all ConfigMaps. See HermesDotEnv for the full
+                                    precedence order.
+                                  items:
+                                    description: |-
+                                      LocalObjectReference contains enough information to let you locate the
+                                      referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  maxItems: 64
+                                  type: array
                               type: object
                               x-kubernetes-validations:
-                              - message: at least one of secretRef or configMapRef
-                                  must be set
+                              - message: at least one of secretRef, configMapRef,
+                                  secretRefs, or configMapRefs must be set
                                 rule: has(self.secretRef) || has(self.configMapRef)
+                                  || has(self.secretRefs) || has(self.configMapRefs)
                             files:
                               additionalProperties:
                                 type: string
@@ -3092,7 +3151,9 @@ spec:
                       type: object
                     description: |-
                       profiles is a map of named Hermes profiles to create and configure.
-                      Each profile is set up via dedicated init containers after the default profile.
+                      Each profile is set up via its own init-profile-<name> init container,
+                      which runs after the consolidated init-hermes container that configures
+                      the default profile.
                     type: object
                   resources:
                     description: resources overrides the resource requests and limits
@@ -3216,15 +3277,20 @@ spec:
                     properties:
                       dotEnv:
                         description: |-
-                          dotEnv generates a $HERMES_HOME/.env file from a Kubernetes Secret
-                          and/or ConfigMap. Each key in the referenced Secret/ConfigMap becomes a
-                          KEY=VALUE line in the file. If both are set, Secret keys override
-                          ConfigMap keys of the same name.
+                          dotEnv generates a $HERMES_HOME/.env file from Kubernetes Secrets
+                          and/or ConfigMaps. Each key in the referenced Secret/ConfigMap becomes a
+                          KEY=VALUE line in the file. Both singular (secretRef/configMapRef) and
+                          plural (secretRefs/configMapRefs) forms are supported and may be
+                          combined; see HermesDotEnv for the precedence order on key collisions.
                         properties:
                           configMapRef:
                             description: |-
                               configMapRef references a Kubernetes ConfigMap whose keys and values are
-                              written as KEY=VALUE lines to $HERMES_HOME/.env.
+                              written as KEY=VALUE lines to $HERMES_HOME/.env. See HermesDotEnv for
+                              the full precedence order on key collisions.
+
+                              Deprecated: Use configMapRefs for new fields; singular forms will be
+                              removed in the v1 type.
                             properties:
                               name:
                                 default: ""
@@ -3237,11 +3303,39 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          configMapRefs:
+                            description: |-
+                              configMapRefs references Kubernetes ConfigMaps whose keys and values
+                              are written as KEY=VALUE lines to $HERMES_HOME/.env. Entries are
+                              applied in order; later entries override earlier ones on key
+                              collision. See HermesDotEnv for the full precedence order.
+                            items:
+                              description: |-
+                                LocalObjectReference contains enough information to let you locate the
+                                referenced object inside the same namespace.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxItems: 64
+                            type: array
                           secretRef:
                             description: |-
                               secretRef references a Kubernetes Secret whose keys and values are
-                              written as KEY=VALUE lines to $HERMES_HOME/.env. If configMapRef is
-                              also set, these values take precedence on key collisions.
+                              written as KEY=VALUE lines to $HERMES_HOME/.env. Secrets override
+                              ConfigMap keys of the same name. See HermesDotEnv for the full
+                              precedence order on key collisions.
+
+                              Deprecated: Use secretRefs for new fields; singular forms will be
+                              removed in the v1 type.
                             properties:
                               name:
                                 default: ""
@@ -3254,11 +3348,37 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          secretRefs:
+                            description: |-
+                              secretRefs references Kubernetes Secrets whose keys and values are
+                              written as KEY=VALUE lines to $HERMES_HOME/.env. Entries are applied
+                              in order; later entries override earlier ones on key collision, and
+                              all Secrets override all ConfigMaps. See HermesDotEnv for the full
+                              precedence order.
+                            items:
+                              description: |-
+                                LocalObjectReference contains enough information to let you locate the
+                                referenced object inside the same namespace.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxItems: 64
+                            type: array
                         type: object
                         x-kubernetes-validations:
-                        - message: at least one of secretRef or configMapRef must
-                            be set
-                          rule: has(self.secretRef) || has(self.configMapRef)
+                        - message: at least one of secretRef, configMapRef, secretRefs,
+                            or configMapRefs must be set
+                          rule: has(self.secretRef) || has(self.configMapRef) || has(self.secretRefs)
+                            || has(self.configMapRefs)
                       files:
                         additionalProperties:
                           type: string
@@ -3271,7 +3391,7 @@ spec:
               initContainers:
                 description: |-
                   InitContainers is a list of additional init containers to run before the main container.
-                  They run after the operator-managed init-config and init-skills containers.
+                  They run after the operator-managed init-hermes and init-profile-<name> containers.
                 items:
                   description: A single application container that you want to run
                     within a pod.

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -3043,15 +3043,20 @@ spec:
                           properties:
                             dotEnv:
                               description: |-
-                                dotEnv generates a $HERMES_HOME/.env file from a Kubernetes Secret
-                                and/or ConfigMap. Each key in the referenced Secret/ConfigMap becomes a
-                                KEY=VALUE line in the file. If both are set, Secret keys override
-                                ConfigMap keys of the same name.
+                                dotEnv generates a $HERMES_HOME/.env file from Kubernetes Secrets
+                                and/or ConfigMaps. Each key in the referenced Secret/ConfigMap becomes a
+                                KEY=VALUE line in the file. Both singular (secretRef/configMapRef) and
+                                plural (secretRefs/configMapRefs) forms are supported and may be
+                                combined; see HermesDotEnv for the precedence order on key collisions.
                               properties:
                                 configMapRef:
                                   description: |-
                                     configMapRef references a Kubernetes ConfigMap whose keys and values are
-                                    written as KEY=VALUE lines to $HERMES_HOME/.env.
+                                    written as KEY=VALUE lines to $HERMES_HOME/.env. See HermesDotEnv for
+                                    the full precedence order on key collisions.
+
+                                    Deprecated: Use configMapRefs for new fields; singular forms will be
+                                    removed in the v1 type.
                                   properties:
                                     name:
                                       default: ""
@@ -3064,11 +3069,39 @@ spec:
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                configMapRefs:
+                                  description: |-
+                                    configMapRefs references Kubernetes ConfigMaps whose keys and values
+                                    are written as KEY=VALUE lines to $HERMES_HOME/.env. Entries are
+                                    applied in order; later entries override earlier ones on key
+                                    collision. See HermesDotEnv for the full precedence order.
+                                  items:
+                                    description: |-
+                                      LocalObjectReference contains enough information to let you locate the
+                                      referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  maxItems: 64
+                                  type: array
                                 secretRef:
                                   description: |-
                                     secretRef references a Kubernetes Secret whose keys and values are
-                                    written as KEY=VALUE lines to $HERMES_HOME/.env. If configMapRef is
-                                    also set, these values take precedence on key collisions.
+                                    written as KEY=VALUE lines to $HERMES_HOME/.env. Secrets override
+                                    ConfigMap keys of the same name. See HermesDotEnv for the full
+                                    precedence order on key collisions.
+
+                                    Deprecated: Use secretRefs for new fields; singular forms will be
+                                    removed in the v1 type.
                                   properties:
                                     name:
                                       default: ""
@@ -3081,11 +3114,37 @@ spec:
                                       type: string
                                   type: object
                                   x-kubernetes-map-type: atomic
+                                secretRefs:
+                                  description: |-
+                                    secretRefs references Kubernetes Secrets whose keys and values are
+                                    written as KEY=VALUE lines to $HERMES_HOME/.env. Entries are applied
+                                    in order; later entries override earlier ones on key collision, and
+                                    all Secrets override all ConfigMaps. See HermesDotEnv for the full
+                                    precedence order.
+                                  items:
+                                    description: |-
+                                      LocalObjectReference contains enough information to let you locate the
+                                      referenced object inside the same namespace.
+                                    properties:
+                                      name:
+                                        default: ""
+                                        description: |-
+                                          Name of the referent.
+                                          This field is effectively required, but due to backwards compatibility is
+                                          allowed to be empty. Instances of this type with an empty value here are
+                                          almost certainly wrong.
+                                          More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                        type: string
+                                    type: object
+                                    x-kubernetes-map-type: atomic
+                                  maxItems: 64
+                                  type: array
                               type: object
                               x-kubernetes-validations:
-                              - message: at least one of secretRef or configMapRef
-                                  must be set
+                              - message: at least one of secretRef, configMapRef,
+                                  secretRefs, or configMapRefs must be set
                                 rule: has(self.secretRef) || has(self.configMapRef)
+                                  || has(self.secretRefs) || has(self.configMapRefs)
                             files:
                               additionalProperties:
                                 type: string
@@ -3097,7 +3156,9 @@ spec:
                       type: object
                     description: |-
                       profiles is a map of named Hermes profiles to create and configure.
-                      Each profile is set up via dedicated init containers after the default profile.
+                      Each profile is set up via its own init-profile-<name> init container,
+                      which runs after the consolidated init-hermes container that configures
+                      the default profile.
                     type: object
                   resources:
                     description: resources overrides the resource requests and limits
@@ -3221,15 +3282,20 @@ spec:
                     properties:
                       dotEnv:
                         description: |-
-                          dotEnv generates a $HERMES_HOME/.env file from a Kubernetes Secret
-                          and/or ConfigMap. Each key in the referenced Secret/ConfigMap becomes a
-                          KEY=VALUE line in the file. If both are set, Secret keys override
-                          ConfigMap keys of the same name.
+                          dotEnv generates a $HERMES_HOME/.env file from Kubernetes Secrets
+                          and/or ConfigMaps. Each key in the referenced Secret/ConfigMap becomes a
+                          KEY=VALUE line in the file. Both singular (secretRef/configMapRef) and
+                          plural (secretRefs/configMapRefs) forms are supported and may be
+                          combined; see HermesDotEnv for the precedence order on key collisions.
                         properties:
                           configMapRef:
                             description: |-
                               configMapRef references a Kubernetes ConfigMap whose keys and values are
-                              written as KEY=VALUE lines to $HERMES_HOME/.env.
+                              written as KEY=VALUE lines to $HERMES_HOME/.env. See HermesDotEnv for
+                              the full precedence order on key collisions.
+
+                              Deprecated: Use configMapRefs for new fields; singular forms will be
+                              removed in the v1 type.
                             properties:
                               name:
                                 default: ""
@@ -3242,11 +3308,39 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          configMapRefs:
+                            description: |-
+                              configMapRefs references Kubernetes ConfigMaps whose keys and values
+                              are written as KEY=VALUE lines to $HERMES_HOME/.env. Entries are
+                              applied in order; later entries override earlier ones on key
+                              collision. See HermesDotEnv for the full precedence order.
+                            items:
+                              description: |-
+                                LocalObjectReference contains enough information to let you locate the
+                                referenced object inside the same namespace.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxItems: 64
+                            type: array
                           secretRef:
                             description: |-
                               secretRef references a Kubernetes Secret whose keys and values are
-                              written as KEY=VALUE lines to $HERMES_HOME/.env. If configMapRef is
-                              also set, these values take precedence on key collisions.
+                              written as KEY=VALUE lines to $HERMES_HOME/.env. Secrets override
+                              ConfigMap keys of the same name. See HermesDotEnv for the full
+                              precedence order on key collisions.
+
+                              Deprecated: Use secretRefs for new fields; singular forms will be
+                              removed in the v1 type.
                             properties:
                               name:
                                 default: ""
@@ -3259,11 +3353,37 @@ spec:
                                 type: string
                             type: object
                             x-kubernetes-map-type: atomic
+                          secretRefs:
+                            description: |-
+                              secretRefs references Kubernetes Secrets whose keys and values are
+                              written as KEY=VALUE lines to $HERMES_HOME/.env. Entries are applied
+                              in order; later entries override earlier ones on key collision, and
+                              all Secrets override all ConfigMaps. See HermesDotEnv for the full
+                              precedence order.
+                            items:
+                              description: |-
+                                LocalObjectReference contains enough information to let you locate the
+                                referenced object inside the same namespace.
+                              properties:
+                                name:
+                                  default: ""
+                                  description: |-
+                                    Name of the referent.
+                                    This field is effectively required, but due to backwards compatibility is
+                                    allowed to be empty. Instances of this type with an empty value here are
+                                    almost certainly wrong.
+                                    More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+                                  type: string
+                              type: object
+                              x-kubernetes-map-type: atomic
+                            maxItems: 64
+                            type: array
                         type: object
                         x-kubernetes-validations:
-                        - message: at least one of secretRef or configMapRef must
-                            be set
-                          rule: has(self.secretRef) || has(self.configMapRef)
+                        - message: at least one of secretRef, configMapRef, secretRefs,
+                            or configMapRefs must be set
+                          rule: has(self.secretRef) || has(self.configMapRef) || has(self.secretRefs)
+                            || has(self.configMapRefs)
                       files:
                         additionalProperties:
                           type: string
@@ -3276,7 +3396,7 @@ spec:
               initContainers:
                 description: |-
                   InitContainers is a list of additional init containers to run before the main container.
-                  They run after the operator-managed init-config and init-skills containers.
+                  They run after the operator-managed init-hermes and init-profile-<name> containers.
                 items:
                   description: A single application container that you want to run
                     within a pod.
@@ -7514,7 +7634,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: test/nope:v1
+        image: ghcr.io/hermeum/hermes-agent-operator:latest
         livenessProbe:
           httpGet:
             path: /healthz

--- a/internal/usecase/hermesagent_hermes_configmap.go
+++ b/internal/usecase/hermesagent_hermes_configmap.go
@@ -205,7 +205,7 @@ func buildHermesConfigMap(ha *agentsv1alpha1.HermesAgent) (*corev1.ConfigMap, er
 	}
 
 	// Operator-managed env vars for the dotenv init container. These keys are
-	// mounted (with an Items filter) into init-dotenv so they land in .env.
+	// mounted (with an Items filter) into the consolidated init-hermes container so they land in .env.
 	// Non-secret values go in the ConfigMap; secret values (API_SERVER_KEY,
 	// WEBHOOK_SECRET) are in the operator Secret and mounted separately.
 	if apiServer := ha.GetHermes().GetAPIServer(); apiServer.IsEnabled() {

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -462,23 +462,30 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 		})
 	}
 
-	// config: init container copies config.yaml from the bootstrap ConfigMap to the data volume.
-	if hc := ha.GetHermes().GetConfig(); hc != nil {
-		initContainers = append(initContainers, initContainer("init-config", buildConfigScript(hermesDefaultProfile)))
-	}
-
-	// workspace: init container copies workspace files from the bootstrap ConfigMap.
-	// ConfigMap keys use the format "profile.default.workspace.<path>" with "/" replaced by "--".
-	initContainers = append(initContainers, initContainer("init-workspace", buildWorkspaceScript(hermesDefaultProfile)))
-
-	// dotenv: init container writes the default profile .env.
+	// A single consolidated init container configures the default profile:
+	// config → workspace → dotenv → packages → plugins → skills → bundles →
+	// crons → stale-profile cleanup. Steps run in subshells so a skipped step
+	// (e.g. "packages up-to-date, exit 0") cannot abort the remaining steps.
 	//
-	// Operator-managed env vars (API_SERVER_*, WEBHOOK_*, SEARXNG_URL,
+	// dotenv: operator-managed env vars (API_SERVER_*, WEBHOOK_*, SEARXNG_URL,
 	// CAMOFOX_URL) are stored as keys in the Hermes ConfigMap and Secret, then
 	// mounted into the init container with Items filters so the existing
 	// `for f in .../*` loop dumps them as KEY=VALUE lines — the same mechanism
 	// as user workspace.dotEnv. Operator mounts come first so user dotEnv keys
 	// override on collision (user wins).
+	var defaultSteps []string
+	var defaultMounts []corev1.VolumeMount
+
+	// config: copy config.yaml from the bootstrap ConfigMap to the data volume.
+	if ha.GetHermes().GetConfig() != nil {
+		defaultSteps = append(defaultSteps, buildConfigScript(hermesDefaultProfile))
+	}
+
+	// workspace: copy workspace files from the bootstrap ConfigMap.
+	// ConfigMap keys use the format "profile.default.workspace.<path>" with "/" replaced by "--".
+	defaultSteps = append(defaultSteps, buildWorkspaceScript(hermesDefaultProfile))
+
+	// dotenv: write the default profile .env.
 	de := ha.GetHermes().GetWorkspace().GetDotEnv()
 	operatorItems := buildOperatorDotEnvItems(ha)
 	operatorSecretItems := buildOperatorDotEnvSecretItems(ha)
@@ -582,205 +589,154 @@ func buildHermesContainer(ha *agentsv1alpha1.HermesAgent, sts *appsv1.StatefulSe
 			}
 		}
 
-		ic := initContainer("init-dotenv", buildDotEnvScript(hermesDefaultProfile, mountPaths...))
-		ic.VolumeMounts = append(ic.VolumeMounts, mounts...)
-		initContainers = append(initContainers, ic)
+		defaultSteps = append(defaultSteps, buildDotEnvScript(hermesDefaultProfile, mountPaths...))
+		defaultMounts = mounts
 	}
 
-	// python-packages: init container installs desired packages into $HERMES_HOME/.python-packages.
-	pythonPackages := ha.GetHermes().GetPackages().GetPip()
-	initContainers = append(initContainers, initContainer("init-python-packages", buildPythonPackagesScript(pythonPackages)))
+	// python-packages: install desired packages into $HERMES_HOME/.python-packages.
+	defaultSteps = append(defaultSteps, buildPythonPackagesScript(ha.GetHermes().GetPackages().GetPip()))
 
-	// npm-packages: init container installs desired packages into $HERMES_HOME/.npm-packages.
-	npmPackages := ha.GetHermes().GetPackages().GetNpm()
-	initContainers = append(initContainers, initContainer("init-npm-packages", buildNPMPackagesScript(npmPackages)))
+	// npm-packages: install desired packages into $HERMES_HOME/.npm-packages.
+	defaultSteps = append(defaultSteps, buildNPMPackagesScript(ha.GetHermes().GetPackages().GetNpm()))
 
-	// plugins: init container installs desired plugins and removes stale ones.
-	plugins := ha.GetHermes().GetPlugins()
-	initContainers = append(initContainers, initContainer("init-plugins", buildPluginsScript(hermesDefaultProfile, plugins)))
+	// plugins: install desired plugins and remove stale ones.
+	defaultSteps = append(defaultSteps, buildPluginsScript(hermesDefaultProfile, ha.GetHermes().GetPlugins()))
 
-	// skills: init container installs/uninstalls skills via the hermes CLI.
-	skills := ha.GetHermes().GetSkills()
-	initContainers = append(initContainers, initContainer("init-skills", buildSkillsScript(hermesDefaultProfile, skills)))
+	// skills: install/uninstall skills via the hermes CLI.
+	defaultSteps = append(defaultSteps, buildSkillsScript(hermesDefaultProfile, ha.GetHermes().GetSkills()))
 
-	// bundles: init container reconciles bundles via the hermes CLI.
-	bundles := ha.GetHermes().GetBundles()
-	initContainers = append(initContainers, initContainer("init-bundles", buildBundlesScript(hermesDefaultProfile, bundles)))
+	// bundles: reconcile bundles via the hermes CLI.
+	defaultSteps = append(defaultSteps, buildBundlesScript(hermesDefaultProfile, ha.GetHermes().GetBundles()))
 
-	// crons: init container reconciles scheduled jobs via the hermes CLI.
-	crons := ha.GetHermes().GetCrons()
-	initContainers = append(initContainers, initContainer("init-crons", buildCronsScript(hermesDefaultProfile, crons)))
+	// crons: reconcile scheduled jobs via the hermes CLI.
+	defaultSteps = append(defaultSteps, buildCronsScript(hermesDefaultProfile, ha.GetHermes().GetCrons()))
 
-	// profiles: create named profiles and configure each with its own init containers.
-	if profiles := ha.GetHermes().GetProfiles(); len(profiles) > 0 {
-		names := sortedProfileNames(profiles)
+	// profiles cleanup: remove named profiles no longer desired and write the
+	// desired profiles manifest. Profile creation happens in the per-profile
+	// init containers below (after the default profile is fully configured, so
+	// --clone copies complete state).
+	profiles := ha.GetHermes().GetProfiles()
+	if len(profiles) > 0 {
+		defaultSteps = append(defaultSteps, buildProfilesCleanupScript(profiles))
+	}
 
-		initContainers = append(initContainers,
-			initContainer("init-profiles", buildProfilesCreationScript(profiles)))
+	initContainers = append(initContainers, func() corev1.Container {
+		ic := initContainer("init-hermes", combineInitSteps(defaultSteps...))
+		ic.VolumeMounts = append(ic.VolumeMounts, defaultMounts...)
+		return ic
+	}())
 
-		{
-			var s strings.Builder
-			for _, name := range names {
-				if profiles[name].Config.GetRaw() != nil {
-					s.WriteString(buildConfigScript(name))
-				}
-			}
-			if s.Len() > 0 {
-				initContainers = append(initContainers,
-					initContainer("init-profiles-config", s.String()))
-			}
+	// One init container per named profile: create the profile, then configure
+	// it (config → workspace → dotenv → plugins → skills → bundles → crons).
+	sidecarItemsForProfiles := buildProfileSidecarDotEnvItems(ha)
+	for _, name := range sortedProfileNames(profiles) {
+		profile := profiles[name]
+		var steps []string
+		var profileMounts []corev1.VolumeMount
+
+		steps = append(steps, buildProfileCreationScript(name, profile.Clone))
+
+		if profile.Config.GetRaw() != nil {
+			steps = append(steps, buildConfigScript(name))
 		}
 
-		{
-			var s strings.Builder
-			for _, name := range names {
-				s.WriteString(buildWorkspaceScript(name))
+		steps = append(steps, buildWorkspaceScript(name))
+
+		// dotenv: SEARXNG_URL / CAMOFOX_URL point at shared sidecars and are
+		// written to every named profile's .env. API_SERVER_* / WEBHOOK_* are
+		// intentionally excluded — they belong to the default profile's
+		// gateway.
+		if de := profile.Workspace.GetDotEnv(); de != nil || len(sidecarItemsForProfiles) > 0 {
+			var mountPaths []string
+
+			// Operator sidecar keys first (user keys override on collision).
+			if len(sidecarItemsForProfiles) > 0 {
+				volName := "hermes-operator-dotenv-profile-" + name
+				mountPath := "/hermes-operator-dotenv-profile-" + name
+				volumes = append(volumes, corev1.Volume{
+					Name: volName,
+					VolumeSource: corev1.VolumeSource{
+						ConfigMap: &corev1.ConfigMapVolumeSource{
+							LocalObjectReference: corev1.LocalObjectReference{Name: ha.GetHermesName()},
+							Items:                sidecarItemsForProfiles,
+						},
+					},
+				})
+				profileMounts = append(profileMounts, corev1.VolumeMount{Name: volName, MountPath: mountPath, ReadOnly: true})
+				mountPaths = append(mountPaths, mountPath)
 			}
-			initContainers = append(initContainers,
-				initContainer("init-profiles-workspace", s.String()))
-		}
 
-		{
-			var s strings.Builder
-			ic := initContainer("init-profiles-dotenv", "")
-			// SEARXNG_URL / CAMOFOX_URL point at shared sidecars and are written
-			// to every named profile's .env. API_SERVER_* / WEBHOOK_* are
-			// intentionally excluded — they belong to the default profile's
-			// gateway.
-			sidecarItems := buildProfileSidecarDotEnvItems(ha)
-			for _, name := range names {
-				de := profiles[name].Workspace.GetDotEnv()
-				if de == nil && len(sidecarItems) == 0 {
-					continue
-				}
-				var mountPaths []string
-
-				// Operator sidecar keys first (user keys override on collision).
-				if len(sidecarItems) > 0 {
-					volName := "hermes-operator-dotenv-profile-" + name
-					mountPath := "/hermes-operator-dotenv-profile-" + name
+			if de != nil {
+				// ConfigMaps: singular first, then plural in order.
+				if de.ConfigMapRef != nil {
+					volName := "hermes-dotenv-configmap-profile-" + name
+					mountPath := "/hermes-dotenv-configmap-profile-" + name
 					volumes = append(volumes, corev1.Volume{
 						Name: volName,
 						VolumeSource: corev1.VolumeSource{
 							ConfigMap: &corev1.ConfigMapVolumeSource{
-								LocalObjectReference: corev1.LocalObjectReference{Name: ha.GetHermesName()},
-								Items:                sidecarItems,
+								LocalObjectReference: corev1.LocalObjectReference{Name: de.ConfigMapRef.Name},
 							},
 						},
 					})
-					ic.VolumeMounts = append(ic.VolumeMounts, corev1.VolumeMount{
-						Name: volName, MountPath: mountPath, ReadOnly: true,
-					})
+					profileMounts = append(profileMounts, corev1.VolumeMount{Name: volName, MountPath: mountPath, ReadOnly: true})
 					mountPaths = append(mountPaths, mountPath)
 				}
 
-				if de != nil {
-					// ConfigMaps: singular first, then plural in order.
-					if de.ConfigMapRef != nil {
-						volName := "hermes-dotenv-configmap-profile-" + name
-						mountPath := "/hermes-dotenv-configmap-profile-" + name
-						volumes = append(volumes, corev1.Volume{
-							Name: volName,
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{Name: de.ConfigMapRef.Name},
-								},
+				for i, ref := range de.ConfigMapRefs {
+					volName := "hermes-dotenv-configmap-profile-" + name + "-" + strconv.Itoa(i)
+					mountPath := "/hermes-dotenv-configmap-profile-" + name + "-" + strconv.Itoa(i)
+					volumes = append(volumes, corev1.Volume{
+						Name: volName,
+						VolumeSource: corev1.VolumeSource{
+							ConfigMap: &corev1.ConfigMapVolumeSource{
+								LocalObjectReference: corev1.LocalObjectReference{Name: ref.Name},
 							},
-						})
-						ic.VolumeMounts = append(ic.VolumeMounts, corev1.VolumeMount{
-							Name: volName, MountPath: mountPath, ReadOnly: true,
-						})
-						mountPaths = append(mountPaths, mountPath)
-					}
-
-					for i, ref := range de.ConfigMapRefs {
-						volName := "hermes-dotenv-configmap-profile-" + name + "-" + strconv.Itoa(i)
-						mountPath := "/hermes-dotenv-configmap-profile-" + name + "-" + strconv.Itoa(i)
-						volumes = append(volumes, corev1.Volume{
-							Name: volName,
-							VolumeSource: corev1.VolumeSource{
-								ConfigMap: &corev1.ConfigMapVolumeSource{
-									LocalObjectReference: corev1.LocalObjectReference{Name: ref.Name},
-								},
-							},
-						})
-						ic.VolumeMounts = append(ic.VolumeMounts, corev1.VolumeMount{
-							Name: volName, MountPath: mountPath, ReadOnly: true,
-						})
-						mountPaths = append(mountPaths, mountPath)
-					}
-
-					// Secrets: singular first, then plural in order.
-					if de.SecretRef != nil {
-						volName := "hermes-dotenv-secret-profile-" + name
-						mountPath := "/hermes-dotenv-secret-profile-" + name
-						volumes = append(volumes, corev1.Volume{
-							Name: volName,
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{SecretName: de.SecretRef.Name},
-							},
-						})
-						ic.VolumeMounts = append(ic.VolumeMounts, corev1.VolumeMount{
-							Name: volName, MountPath: mountPath, ReadOnly: true,
-						})
-						mountPaths = append(mountPaths, mountPath)
-					}
-
-					for i, ref := range de.SecretRefs {
-						volName := "hermes-dotenv-secret-profile-" + name + "-" + strconv.Itoa(i)
-						mountPath := "/hermes-dotenv-secret-profile-" + name + "-" + strconv.Itoa(i)
-						volumes = append(volumes, corev1.Volume{
-							Name: volName,
-							VolumeSource: corev1.VolumeSource{
-								Secret: &corev1.SecretVolumeSource{SecretName: ref.Name},
-							},
-						})
-						ic.VolumeMounts = append(ic.VolumeMounts, corev1.VolumeMount{
-							Name: volName, MountPath: mountPath, ReadOnly: true,
-						})
-						mountPaths = append(mountPaths, mountPath)
-					}
+						},
+					})
+					profileMounts = append(profileMounts, corev1.VolumeMount{Name: volName, MountPath: mountPath, ReadOnly: true})
+					mountPaths = append(mountPaths, mountPath)
 				}
 
-				s.WriteString(buildDotEnvScript(name, mountPaths...))
+				// Secrets: singular first, then plural in order.
+				if de.SecretRef != nil {
+					volName := "hermes-dotenv-secret-profile-" + name
+					mountPath := "/hermes-dotenv-secret-profile-" + name
+					volumes = append(volumes, corev1.Volume{
+						Name: volName,
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{SecretName: de.SecretRef.Name},
+						},
+					})
+					profileMounts = append(profileMounts, corev1.VolumeMount{Name: volName, MountPath: mountPath, ReadOnly: true})
+					mountPaths = append(mountPaths, mountPath)
+				}
+
+				for i, ref := range de.SecretRefs {
+					volName := "hermes-dotenv-secret-profile-" + name + "-" + strconv.Itoa(i)
+					mountPath := "/hermes-dotenv-secret-profile-" + name + "-" + strconv.Itoa(i)
+					volumes = append(volumes, corev1.Volume{
+						Name: volName,
+						VolumeSource: corev1.VolumeSource{
+							Secret: &corev1.SecretVolumeSource{SecretName: ref.Name},
+						},
+					})
+					profileMounts = append(profileMounts, corev1.VolumeMount{Name: volName, MountPath: mountPath, ReadOnly: true})
+					mountPaths = append(mountPaths, mountPath)
+				}
 			}
-			if s.Len() > 0 {
-				ic.Args = []string{s.String()}
-				initContainers = append(initContainers, ic)
-			}
+
+			steps = append(steps, buildDotEnvScript(name, mountPaths...))
 		}
 
-		{
-			var s strings.Builder
-			for _, name := range names {
-				s.WriteString(buildPluginsScript(name, profiles[name].Plugins))
-			}
-			initContainers = append(initContainers, initContainer("init-profiles-plugins", s.String()))
-		}
+		steps = append(steps, buildPluginsScript(name, profile.Plugins))
+		steps = append(steps, buildSkillsScript(name, profile.Skills))
+		steps = append(steps, buildBundlesScript(name, profile.Bundles))
+		steps = append(steps, buildCronsScript(name, profile.Crons))
 
-		{
-			var s strings.Builder
-			for _, name := range names {
-				s.WriteString(buildSkillsScript(name, profiles[name].Skills))
-			}
-			initContainers = append(initContainers, initContainer("init-profiles-skills", s.String()))
-		}
-
-		{
-			var s strings.Builder
-			for _, name := range names {
-				s.WriteString(buildBundlesScript(name, profiles[name].Bundles))
-			}
-			initContainers = append(initContainers, initContainer("init-profiles-bundles", s.String()))
-		}
-
-		{
-			var s strings.Builder
-			for _, name := range names {
-				s.WriteString(buildCronsScript(name, profiles[name].Crons))
-			}
-			initContainers = append(initContainers, initContainer("init-profiles-crons", s.String()))
-		}
+		ic := initContainer("init-profile-"+name, combineInitSteps(steps...))
+		ic.VolumeMounts = append(ic.VolumeMounts, profileMounts...)
+		initContainers = append(initContainers, ic)
 	}
 
 	// initScripts: user-provided scripts run as init containers after all managed ones.
@@ -1432,19 +1388,13 @@ func sortedProfileNames(profiles map[string]agentsv1alpha1.HermesProfile) []stri
 	return names
 }
 
-func buildProfilesCreationScript(profiles map[string]agentsv1alpha1.HermesProfile) string {
+// buildProfilesCleanupScript removes named profiles no longer desired and
+// rewrites the profiles manifest. It runs inside the consolidated init-hermes
+// container; profile creation happens in the per-profile init containers.
+func buildProfilesCleanupScript(profiles map[string]agentsv1alpha1.HermesProfile) string {
 	names := sortedProfileNames(profiles)
 	casePattern := `"` + strings.Join(names, `"|"`) + `"`
 	manifestContent := strings.Join(names, "\n")
-
-	createLines := make([]string, 0, len(names))
-	for _, name := range names {
-		cmd := fmt.Sprintf("hermes profile create %q --no-alias", name)
-		if profiles[name].Clone {
-			cmd += " --clone"
-		}
-		createLines = append(createLines, cmd+" || true")
-	}
 
 	return fmt.Sprintf(`set -eu
 PROFILES_MANIFEST="$HERMES_HOME/.hermes-agent-operator/profiles-manifest"
@@ -1460,12 +1410,36 @@ if [ -f "$PROFILES_MANIFEST" ]; then
   done < "$PROFILES_MANIFEST"
 fi
 
-%s
-
 cat > "$PROFILES_MANIFEST" << 'PROFILES_EOF'
 %s
 PROFILES_EOF
-`, casePattern, strings.Join(createLines, "\n"), manifestContent)
+`, casePattern, manifestContent)
+}
+
+// buildProfileCreationScript creates a single named profile. It runs as the
+// first step of the profile's own init container, after the default profile
+// has been fully configured (so --clone copies complete state).
+func buildProfileCreationScript(name string, clone bool) string {
+	cmd := fmt.Sprintf("hermes profile create %q --no-alias", name)
+	if clone {
+		cmd += " --clone"
+	}
+	return fmt.Sprintf(`set -eu
+%s || true
+echo "Profile %s ready"
+`, cmd, name)
+}
+
+// combineInitSteps joins step scripts into a single init script. Each step is
+// wrapped in a subshell so steps that exit early (e.g. "packages up-to-date,
+// exit 0") cannot abort the remaining steps, and a banner echoes the step
+// number for diagnosability.
+func combineInitSteps(steps ...string) string {
+	var s strings.Builder
+	for i, step := range steps {
+		fmt.Fprintf(&s, "echo '==> Step %d/%d'\n(\n%s\n)\n", i+1, len(steps), step)
+	}
+	return s.String()
 }
 
 func buildCronsScript(profile string, crons []agentsv1alpha1.HermesCron) string {

--- a/internal/usecase/hermesagent_statefulset_test.go
+++ b/internal/usecase/hermesagent_statefulset_test.go
@@ -6,13 +6,20 @@ import (
 
 	agentsv1alpha1 "hermeum/hermes-agent-operator/api/v1alpha1"
 
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const testTrue = "true"
+const (
+	testTrue = "true"
+	// consolidatedInitContainerName is the name of the operator-managed init
+	// container that configures the default profile.
+	consolidatedInitContainerName = "init-hermes"
+)
 
 func minimalHA() *agentsv1alpha1.HermesAgent {
 	return &agentsv1alpha1.HermesAgent{
@@ -614,7 +621,7 @@ func hasVolumeMount(mounts []corev1.VolumeMount, name string) bool {
 }
 
 func TestOperatorDotEnvAPIServer(t *testing.T) {
-	t.Run("enabled: ConfigMap has operator keys, init-dotenv mounts them", func(t *testing.T) {
+	t.Run("enabled: ConfigMap has operator keys, init-hermes mounts them", func(t *testing.T) {
 		ha := minimalHA()
 		ha.Spec.Hermes = &agentsv1alpha1.Hermes{
 			Config: &agentsv1alpha1.HermesConfig{
@@ -639,17 +646,17 @@ func TestOperatorDotEnvAPIServer(t *testing.T) {
 			t.Errorf("expected API_SERVER_HOST=0.0.0.0, got %q", cm.Data["API_SERVER_HOST"])
 		}
 
-		// init-dotenv must exist and mount the operator ConfigMap and Secret.
+		// init-hermes must exist and mount the operator ConfigMap and Secret.
 		sts := buildStatefulSet(ha)
-		ic := findInitContainer(sts, "init-dotenv")
+		ic := findInitContainer(sts, consolidatedInitContainerName)
 		if ic == nil {
-			t.Fatal("expected init-dotenv init container")
+			t.Fatal("expected init-hermes init container")
 		}
 		if !hasVolumeMount(ic.VolumeMounts, "hermes-operator-dotenv-configmap") {
-			t.Error("expected hermes-operator-dotenv-configmap volume mount on init-dotenv")
+			t.Error("expected hermes-operator-dotenv-configmap volume mount on init-hermes")
 		}
 		if !hasVolumeMount(ic.VolumeMounts, "hermes-operator-dotenv-secret") {
-			t.Error("expected hermes-operator-dotenv-secret volume mount on init-dotenv")
+			t.Error("expected hermes-operator-dotenv-secret volume mount on init-hermes")
 		}
 		// The script must iterate the operator mount paths.
 		if !strings.Contains(ic.Args[0], "/hermes-operator-dotenv-configmap") {
@@ -707,7 +714,7 @@ func TestOperatorDotEnvAPIServer(t *testing.T) {
 		}
 	})
 
-	t.Run("disabled: no operator keys in ConfigMap, no init-dotenv", func(t *testing.T) {
+	t.Run("disabled: no operator keys in ConfigMap, no dotenv section", func(t *testing.T) {
 		ha := minimalHA()
 		cm, err := buildHermesConfigMap(ha)
 		if err != nil {
@@ -719,8 +726,12 @@ func TestOperatorDotEnvAPIServer(t *testing.T) {
 			}
 		}
 		sts := buildStatefulSet(ha)
-		if ic := findInitContainer(sts, "init-dotenv"); ic != nil {
-			t.Errorf("expected no init-dotenv when nothing enabled, got: %v", ic)
+		ic := findInitContainer(sts, consolidatedInitContainerName)
+		if ic == nil {
+			t.Fatal("expected init-hermes")
+		}
+		if strings.Contains(ic.Args[0], "hermes config env-path") {
+			t.Errorf("expected no dotenv section in init-hermes when nothing enabled, got:\n%s", ic.Args[0])
 		}
 	})
 }
@@ -745,12 +756,12 @@ func TestOperatorDotEnvWebhook(t *testing.T) {
 	}
 
 	sts := buildStatefulSet(ha)
-	ic := findInitContainer(sts, "init-dotenv")
+	ic := findInitContainer(sts, consolidatedInitContainerName)
 	if ic == nil {
-		t.Fatal("expected init-dotenv init container")
+		t.Fatal("expected init-hermes init container")
 	}
 	if !hasVolumeMount(ic.VolumeMounts, "hermes-operator-dotenv-secret") {
-		t.Error("expected hermes-operator-dotenv-secret volume mount on init-dotenv")
+		t.Error("expected hermes-operator-dotenv-secret volume mount on init-hermes")
 	}
 
 	// WEBHOOK_* env vars are injected via .env, not container env.
@@ -766,7 +777,7 @@ func TestOperatorDotEnvWebhook(t *testing.T) {
 }
 
 func TestOperatorDotEnvSidecars(t *testing.T) {
-	t.Run("searxng: SEARXNG_URL in ConfigMap and init-dotenv", func(t *testing.T) {
+	t.Run("searxng: SEARXNG_URL in ConfigMap and init-hermes", func(t *testing.T) {
 		ha := minimalHA()
 		ha.Spec.SearXNG = &agentsv1alpha1.SearXNG{Enabled: true}
 
@@ -779,9 +790,9 @@ func TestOperatorDotEnvSidecars(t *testing.T) {
 		}
 
 		sts := buildStatefulSet(ha)
-		ic := findInitContainer(sts, "init-dotenv")
+		ic := findInitContainer(sts, consolidatedInitContainerName)
 		if ic == nil {
-			t.Fatal("expected init-dotenv init container")
+			t.Fatal("expected init-hermes init container")
 		}
 		if !strings.Contains(ic.Args[0], "/hermes-operator-dotenv-configmap") {
 			t.Errorf("expected operator configmap mount path in script, got:\n%s", ic.Args[0])
@@ -796,7 +807,7 @@ func TestOperatorDotEnvSidecars(t *testing.T) {
 		}
 	})
 
-	t.Run("camofox: CAMOFOX_URL in ConfigMap and init-dotenv", func(t *testing.T) {
+	t.Run("camofox: CAMOFOX_URL in ConfigMap and init-hermes", func(t *testing.T) {
 		ha := minimalHA()
 		ha.Spec.Camofox = &agentsv1alpha1.Camofox{Enabled: true}
 
@@ -809,9 +820,9 @@ func TestOperatorDotEnvSidecars(t *testing.T) {
 		}
 
 		sts := buildStatefulSet(ha)
-		ic := findInitContainer(sts, "init-dotenv")
+		ic := findInitContainer(sts, consolidatedInitContainerName)
 		if ic == nil {
-			t.Fatal("expected init-dotenv init container")
+			t.Fatal("expected init-hermes init container")
 		}
 		if !strings.Contains(ic.Args[0], "/hermes-operator-dotenv-configmap") {
 			t.Errorf("expected operator configmap mount path in script, got:\n%s", ic.Args[0])
@@ -845,42 +856,47 @@ func TestOperatorDotEnvMultiplex(t *testing.T) {
 		sts := buildStatefulSet(ha)
 
 		// Default profile: operator ConfigMap + Secret mounted.
-		defIC := findInitContainer(sts, "init-dotenv")
+		defIC := findInitContainer(sts, consolidatedInitContainerName)
 		if defIC == nil {
-			t.Fatal("expected init-dotenv")
+			t.Fatal("expected init-hermes")
 		}
 		if !hasVolumeMount(defIC.VolumeMounts, "hermes-operator-dotenv-configmap") {
-			t.Error("expected operator configmap mount on default init-dotenv")
+			t.Error("expected operator configmap mount on default init-hermes")
 		}
 		if !hasVolumeMount(defIC.VolumeMounts, "hermes-operator-dotenv-secret") {
-			t.Error("expected operator secret mount on default init-dotenv")
+			t.Error("expected operator secret mount on default init-hermes")
 		}
 
 		// Named profiles: only sidecar URLs, no API_SERVER_*/WEBHOOK_*.
-		profIC := findInitContainer(sts, "init-profiles-dotenv")
-		if profIC == nil {
-			t.Fatal("expected init-profiles-dotenv")
+		coderIC := findInitContainer(sts, "init-profile-coder")
+		if coderIC == nil {
+			t.Fatal("expected init-profile-coder")
 		}
-		profScript := profIC.Args[0]
-		if !strings.Contains(profScript, "hermes-operator-dotenv-profile-coder") {
-			t.Errorf("expected operator dotenv mount for coder profile, got:\n%s", profScript)
-		}
-		if !strings.Contains(profScript, "hermes-operator-dotenv-profile-writer") {
-			t.Errorf("expected operator dotenv mount for writer profile, got:\n%s", profScript)
+		coderScript := coderIC.Args[0]
+		if !strings.Contains(coderScript, "hermes-operator-dotenv-profile-coder") {
+			t.Errorf("expected operator dotenv mount for coder profile, got:\n%s", coderScript)
 		}
 		// Must NOT have API_SERVER or WEBHOOK in named-profile dotenv.
-		if strings.Contains(profScript, "API_SERVER") {
-			t.Errorf("API_SERVER_* must not appear in named-profile dotenv, got:\n%s", profScript)
+		if strings.Contains(coderScript, "API_SERVER") {
+			t.Errorf("API_SERVER_* must not appear in named-profile dotenv, got:\n%s", coderScript)
 		}
-		if strings.Contains(profScript, "WEBHOOK") {
-			t.Errorf("WEBHOOK_* must not appear in named-profile dotenv, got:\n%s", profScript)
+		if strings.Contains(coderScript, "WEBHOOK") {
+			t.Errorf("WEBHOOK_* must not appear in named-profile dotenv, got:\n%s", coderScript)
 		}
-		// Each named profile gets its own .env block.
-		if strings.Count(profScript, `hermes config env-path -p "coder"`) != 1 {
-			t.Errorf("expected one coder dotenv block, got:\n%s", profScript)
+		// Each named profile gets its own .env block and its own container.
+		if strings.Count(coderScript, `hermes config env-path -p "coder"`) != 1 {
+			t.Errorf("expected one coder dotenv block, got:\n%s", coderScript)
 		}
-		if strings.Count(profScript, `hermes config env-path -p "writer"`) != 1 {
-			t.Errorf("expected one writer dotenv block, got:\n%s", profScript)
+		writerIC := findInitContainer(sts, "init-profile-writer")
+		if writerIC == nil {
+			t.Fatal("expected init-profile-writer")
+		}
+		writerScript := writerIC.Args[0]
+		if !strings.Contains(writerScript, "hermes-operator-dotenv-profile-writer") {
+			t.Errorf("expected operator dotenv mount for writer profile, got:\n%s", writerScript)
+		}
+		if strings.Contains(writerScript, "hermes-operator-dotenv-profile-coder") {
+			t.Errorf("writer container must not mount coder dotenv volume, got:\n%s", writerScript)
 		}
 	})
 }
@@ -899,9 +915,9 @@ func TestOperatorDotEnvCollision(t *testing.T) {
 		},
 	}
 	sts := buildStatefulSet(ha)
-	ic := findInitContainer(sts, "init-dotenv")
+	ic := findInitContainer(sts, consolidatedInitContainerName)
 	if ic == nil {
-		t.Fatal("expected init-dotenv")
+		t.Fatal("expected init-hermes")
 	}
 	script := ic.Args[0]
 	// Operator mount path must come before user mount path.
@@ -924,28 +940,27 @@ func TestOperatorDotEnvOrdering(t *testing.T) {
 		},
 	}
 	sts := buildStatefulSet(ha)
-	var workspaceIdx, dotenvIdx = -1, -1
-	for i, c := range sts.Spec.Template.Spec.InitContainers {
-		switch c.Name {
-		case "init-workspace":
-			workspaceIdx = i
-		case "init-dotenv":
-			dotenvIdx = i
-		}
+	ic := findInitContainer(sts, consolidatedInitContainerName)
+	if ic == nil {
+		t.Fatal("expected init-hermes")
 	}
+	script := ic.Args[0]
+	// workspace step must run before the dotenv step inside the consolidated script.
+	workspaceIdx := strings.Index(script, "profile.default.workspace.")
+	dotenvIdx := strings.Index(script, `hermes config env-path -p "default"`)
 	if workspaceIdx < 0 {
-		t.Fatal("init-workspace not found")
+		t.Fatal("workspace step not found in init-hermes script")
 	}
 	if dotenvIdx < 0 {
-		t.Fatal("init-dotenv not found")
+		t.Fatal("dotenv step not found in init-hermes script")
 	}
 	if dotenvIdx <= workspaceIdx {
-		t.Errorf("expected init-dotenv (idx %d) after init-workspace (idx %d)", dotenvIdx, workspaceIdx)
+		t.Errorf("expected dotenv step after workspace step; workspace at %d, dotenv at %d", workspaceIdx, dotenvIdx)
 	}
 }
 
 func TestOperatorDotEnvUserDotEnvAlone(t *testing.T) {
-	// User dotEnv without any operator features still emits init-dotenv.
+	// User dotEnv without any operator features still emits a dotenv section in init-hermes.
 	ha := minimalHA()
 	ha.Spec.Hermes = &agentsv1alpha1.Hermes{
 		Workspace: &agentsv1alpha1.HermesWorkspace{
@@ -955,8 +970,8 @@ func TestOperatorDotEnvUserDotEnvAlone(t *testing.T) {
 		},
 	}
 	sts := buildStatefulSet(ha)
-	if findInitContainer(sts, "init-dotenv") == nil {
-		t.Error("expected init-dotenv when user dotEnv is set")
+	if findInitContainer(sts, consolidatedInitContainerName) == nil {
+		t.Error("expected dotenv section in init-hermes when user dotEnv is set")
 	}
 }
 
@@ -974,9 +989,9 @@ func TestDotEnvPluralConfigMapRefs(t *testing.T) {
 		},
 	}
 	sts := buildStatefulSet(ha)
-	ic := findInitContainer(sts, "init-dotenv")
+	ic := findInitContainer(sts, consolidatedInitContainerName)
 	if ic == nil {
-		t.Fatal("expected init-dotenv")
+		t.Fatal("expected init-hermes")
 	}
 	script := ic.Args[0]
 	// Both plural configmap mount paths must be present, in order.
@@ -1014,9 +1029,9 @@ func TestDotEnvPluralSecretRefs(t *testing.T) {
 		},
 	}
 	sts := buildStatefulSet(ha)
-	ic := findInitContainer(sts, "init-dotenv")
+	ic := findInitContainer(sts, consolidatedInitContainerName)
 	if ic == nil {
-		t.Fatal("expected init-dotenv")
+		t.Fatal("expected init-hermes")
 	}
 	script := ic.Args[0]
 	idx0 := strings.Index(script, "/hermes-dotenv-secret-0")
@@ -1052,9 +1067,9 @@ func TestDotEnvMixedSingularAndPluralOrder(t *testing.T) {
 		},
 	}
 	sts := buildStatefulSet(ha)
-	ic := findInitContainer(sts, "init-dotenv")
+	ic := findInitContainer(sts, consolidatedInitContainerName)
 	if ic == nil {
-		t.Fatal("expected init-dotenv")
+		t.Fatal("expected init-hermes")
 	}
 	script := ic.Args[0]
 	// Expected order: configmap (singular) < configmap-0 < secret (singular) < secret-0.
@@ -1099,9 +1114,9 @@ func TestDotEnvPluralRefsPerProfile(t *testing.T) {
 		},
 	}
 	sts := buildStatefulSet(ha)
-	ic := findInitContainer(sts, "init-profiles-dotenv")
+	ic := findInitContainer(sts, "init-profile-writer")
 	if ic == nil {
-		t.Fatal("expected init-profiles-dotenv")
+		t.Fatal("expected init-profile-writer")
 	}
 	cmFound := false
 	secFound := false
@@ -1118,5 +1133,209 @@ func TestDotEnvPluralRefsPerProfile(t *testing.T) {
 	}
 	if !secFound {
 		t.Error("expected per-profile plural secret volume mount")
+	}
+}
+
+func TestConsolidatedInitContainers(t *testing.T) {
+	ha := minimalHA()
+	ha.Spec.Hermes = &agentsv1alpha1.Hermes{
+		Config: &agentsv1alpha1.HermesConfig{
+			Raw: &apiextensionsv1.JSON{Raw: []byte(`{"foo":"bar"}`)},
+		},
+		Profiles: map[string]agentsv1alpha1.HermesProfile{
+			"writer": {Clone: true},
+			"coder":  {},
+		},
+	}
+	ha.Spec.Hermes.Plugins = []agentsv1alpha1.HermesPlugin{{Identifier: "owner/repo"}}
+	ha.Spec.Hermes.Skills = []agentsv1alpha1.HermesSkill{{Identifier: "gh-aw/system-commands"}}
+	ha.Spec.Hermes.Packages = &agentsv1alpha1.HermesPackages{
+		Pip: &agentsv1alpha1.HermesPipPackages{Install: []string{"requests"}},
+		Npm: &agentsv1alpha1.HermesNpmPackages{Install: []string{"typescript"}},
+	}
+	ha.Spec.Hermes.Bundles = []agentsv1alpha1.HermesBundle{{Name: "ops"}}
+	ha.Spec.Hermes.Crons = []agentsv1alpha1.HermesCron{{Name: "daily", Schedule: "1h"}}
+	ha.Spec.Hermes.Workspace = &agentsv1alpha1.HermesWorkspace{
+		DotEnv: &agentsv1alpha1.HermesDotEnv{
+			SecretRef: &corev1.LocalObjectReference{Name: "my-env"},
+		},
+	}
+
+	sts := buildStatefulSet(ha)
+
+	// Exactly one consolidated default-profile init container.
+	var initHermes []*corev1.Container
+	var profileInits []*corev1.Container
+	for i := range sts.Spec.Template.Spec.InitContainers {
+		c := &sts.Spec.Template.Spec.InitContainers[i]
+		switch {
+		case c.Name == consolidatedInitContainerName:
+			initHermes = append(initHermes, c)
+		case strings.HasPrefix(c.Name, "init-profile-"):
+			profileInits = append(profileInits, c)
+		}
+	}
+	if len(initHermes) != 1 {
+		t.Fatalf("expected exactly one init-hermes, got %d", len(initHermes))
+	}
+	script := initHermes[0].Args[0]
+
+	// All default-profile steps present in the consolidated script, in order.
+	type step struct {
+		marker string
+		desc   string
+	}
+	steps := []step{
+		{`cp "/bootstrap/profile.default.config.yaml"`, "config"},
+		{"profile.default.workspace.", "workspace"},
+		{`hermes config env-path -p "default"`, "dotenv"},
+		{".python-packages", "python packages"},
+		{".npm-packages", "npm packages"},
+		{`hermes plugins install -p "default"`, "plugins"},
+		{`hermes skills install -p "default"`, "skills"},
+		{`hermes bundles create -p "default"`, "bundles"},
+		{`hermes cron create -p "default"`, "crons"},
+		{"profiles-manifest", "profiles cleanup"},
+	}
+	last := -1
+	for _, st := range steps {
+		idx := strings.Index(script, st.marker)
+		if idx < 0 {
+			t.Errorf("expected %s step in init-hermes script, got:\n%s", st.desc, script)
+			continue
+		}
+		if idx < last {
+			t.Errorf("expected %s step after previous step; %d < %d", st.desc, idx, last)
+		}
+		last = idx
+	}
+
+	// Steps run in subshells so early exit cannot abort later steps.
+	if strings.Count(script, "\n(\n") != len(steps) {
+		t.Errorf("expected %d subshells in init-hermes script, got %d:\n%s", len(steps), strings.Count(script, "\n(\n"), script)
+	}
+
+	// One init container per named profile, sorted alphabetically.
+	if len(profileInits) != 2 {
+		t.Fatalf("expected 2 per-profile init containers, got %d: %v", len(profileInits), profileInits)
+	}
+	if profileInits[0].Name != "init-profile-coder" || profileInits[1].Name != "init-profile-writer" {
+		t.Errorf("expected sorted profile containers [init-profile-coder init-profile-writer], got [%s %s]",
+			profileInits[0].Name, profileInits[1].Name)
+	}
+
+	// Each profile container creates its profile and configures it.
+	coderScript := profileInits[0].Args[0]
+	if !strings.Contains(coderScript, `hermes profile create "coder" --no-alias`) {
+		t.Errorf("expected profile creation in coder container, got:\n%s", coderScript)
+	}
+	if strings.Contains(coderScript, "--clone") {
+		t.Errorf("coder profile has clone=false, got:\n%s", coderScript)
+	}
+	if !strings.Contains(coderScript, `hermes config path -p "coder"`) {
+		t.Errorf("expected workspace setup in coder container, got:\n%s", coderScript)
+	}
+	writerScript := profileInits[1].Args[0]
+	if !strings.Contains(writerScript, `hermes profile create "writer" --no-alias --clone`) {
+		t.Errorf("expected clone in writer container, got:\n%s", writerScript)
+	}
+
+	// Profile containers run after init-hermes.
+	initHermesIdx := -1
+	for i, c := range sts.Spec.Template.Spec.InitContainers {
+		if c.Name == consolidatedInitContainerName {
+			initHermesIdx = i
+		}
+	}
+	for _, c := range profileInits {
+		found := -1
+		for i, cc := range sts.Spec.Template.Spec.InitContainers {
+			if cc.Name == c.Name {
+				found = i
+			}
+		}
+		if found <= initHermesIdx {
+			t.Errorf("expected %s after init-hermes (idx %d), got idx %d", c.Name, initHermesIdx, found)
+		}
+	}
+
+	// User initScripts run after all operator-managed init containers.
+	ha.Spec.Hermes.InitScripts = []agentsv1alpha1.HermesInitScript{{Name: "extra", Script: "echo hi"}}
+	sts2 := buildStatefulSet(ha)
+	extraIdx, lastManaged := -1, -1
+	for i, c := range sts2.Spec.Template.Spec.InitContainers {
+		if c.Name == "extra" {
+			extraIdx = i
+		}
+		if c.Name == consolidatedInitContainerName || strings.HasPrefix(c.Name, "init-profile-") {
+			lastManaged = i
+		}
+	}
+	if extraIdx < 0 || extraIdx <= lastManaged {
+		t.Errorf("expected user initScript after managed init containers; extra idx %d, last managed idx %d", extraIdx, lastManaged)
+	}
+}
+
+func TestConsolidatedInitContainersMinimal(t *testing.T) {
+	// No profiles: only init-hermes, no per-profile containers; no dotenv section.
+	ha := minimalHA()
+	sts := buildStatefulSet(ha)
+	if findInitContainer(sts, consolidatedInitContainerName) == nil {
+		t.Fatal("expected init-hermes")
+	}
+	for _, c := range sts.Spec.Template.Spec.InitContainers {
+		if strings.HasPrefix(c.Name, "init-profile-") {
+			t.Errorf("unexpected per-profile container without profiles: %s", c.Name)
+		}
+	}
+	if strings.Contains(findInitContainer(sts, consolidatedInitContainerName).Args[0], "hermes config env-path") {
+		t.Error("expected no dotenv section with empty spec")
+	}
+	if strings.Contains(findInitContainer(sts, consolidatedInitContainerName).Args[0], "profiles-manifest") {
+		t.Error("expected no profiles cleanup without profiles")
+	}
+}
+
+func TestBuildProfilesCleanupScript(t *testing.T) {
+	got := buildProfilesCleanupScript(map[string]agentsv1alpha1.HermesProfile{
+		"a": {},
+		"b": {},
+	})
+	if !strings.Contains(got, `hermes profile delete "$pname" || true`) {
+		t.Errorf("expected stale profile deletion, got:\n%s", got)
+	}
+	if strings.Contains(got, "profile create") {
+		t.Errorf("cleanup script must not create profiles, got:\n%s", got)
+	}
+	if !strings.Contains(got, "a\nb") {
+		t.Errorf("expected manifest with sorted names a\\nb, got:\n%s", got)
+	}
+}
+
+func TestBuildProfileCreationScript(t *testing.T) {
+	got := buildProfileCreationScript("coder", true)
+	if !strings.Contains(got, `hermes profile create "coder" --no-alias --clone || true`) {
+		t.Errorf("expected create with clone, got:\n%s", got)
+	}
+	got2 := buildProfileCreationScript("writer", false)
+	if !strings.Contains(got2, `hermes profile create "writer" --no-alias || true`) {
+		t.Errorf("expected create without clone, got:\n%s", got2)
+	}
+	if strings.Contains(got2, "--clone") {
+		t.Errorf("unexpected --clone flag, got:\n%s", got2)
+	}
+}
+
+func TestCombineInitSteps(t *testing.T) {
+	got := combineInitSteps("step one", "step two")
+	if !strings.Contains(got, "==> Step 1/2") || !strings.Contains(got, "==> Step 2/2") {
+		t.Errorf("expected step banners, got:\n%s", got)
+	}
+	if !strings.Contains(got, "step one") || !strings.Contains(got, "step two") {
+		t.Errorf("expected both steps in script, got:\n%s", got)
+	}
+	// Each step wrapped in a subshell so `exit 0` in one step cannot abort the next.
+	if strings.Count(got, "\n(\n") != 2 {
+		t.Errorf("expected 2 subshells, got:\n%s", got)
 	}
 }

--- a/skills/hermes-agent-operator/crd.yaml
+++ b/skills/hermes-agent-operator/crd.yaml
@@ -3046,6 +3046,9 @@ spec:
                                     configMapRef references a Kubernetes ConfigMap whose keys and values are
                                     written as KEY=VALUE lines to $HERMES_HOME/.env. See HermesDotEnv for
                                     the full precedence order on key collisions.
+
+                                    Deprecated: Use configMapRefs for new fields; singular forms will be
+                                    removed in the v1 type.
                                   properties:
                                     name:
                                       default: ""
@@ -3088,6 +3091,9 @@ spec:
                                     written as KEY=VALUE lines to $HERMES_HOME/.env. Secrets override
                                     ConfigMap keys of the same name. See HermesDotEnv for the full
                                     precedence order on key collisions.
+
+                                    Deprecated: Use secretRefs for new fields; singular forms will be
+                                    removed in the v1 type.
                                   properties:
                                     name:
                                       default: ""
@@ -3142,7 +3148,9 @@ spec:
                       type: object
                     description: |-
                       profiles is a map of named Hermes profiles to create and configure.
-                      Each profile is set up via dedicated init containers after the default profile.
+                      Each profile is set up via its own init-profile-<name> init container,
+                      which runs after the consolidated init-hermes container that configures
+                      the default profile.
                     type: object
                   resources:
                     description: resources overrides the resource requests and limits
@@ -3277,6 +3285,9 @@ spec:
                               configMapRef references a Kubernetes ConfigMap whose keys and values are
                               written as KEY=VALUE lines to $HERMES_HOME/.env. See HermesDotEnv for
                               the full precedence order on key collisions.
+
+                              Deprecated: Use configMapRefs for new fields; singular forms will be
+                              removed in the v1 type.
                             properties:
                               name:
                                 default: ""
@@ -3319,6 +3330,9 @@ spec:
                               written as KEY=VALUE lines to $HERMES_HOME/.env. Secrets override
                               ConfigMap keys of the same name. See HermesDotEnv for the full
                               precedence order on key collisions.
+
+                              Deprecated: Use secretRefs for new fields; singular forms will be
+                              removed in the v1 type.
                             properties:
                               name:
                                 default: ""
@@ -3374,7 +3388,7 @@ spec:
               initContainers:
                 description: |-
                   InitContainers is a list of additional init containers to run before the main container.
-                  They run after the operator-managed init-config and init-skills containers.
+                  They run after the operator-managed init-hermes and init-profile-<name> containers.
                 items:
                   description: A single application container that you want to run
                     within a pod.


### PR DESCRIPTION
## Summary

Reduces the number of operator-managed init containers from up to ~18 to **1 + N** (1 consolidated default-profile container + 1 per named profile), cutting pod setup time (N container startups instead of N + M) and producing a leaner pod spec.

## Changes

### Consolidated default-profile container: `init-hermes`
Merges `init-config`, `init-workspace`, `init-dotenv`, `init-python-packages`, `init-npm-packages`, `init-plugins`, `init-skills`, `init-bundles`, `init-crons`, plus stale-profile cleanup into a single container. Each step:
- runs in a **subshell**, so a skipped step (e.g. `Python packages up-to-date, exit 0`) cannot abort later steps
- is preceded by an `echo '==> Step N/M'` banner, keeping failures diagnosable in container logs

### Per-profile container: `init-profile-<name>`
Replaces the 8 `init-profiles-*` containers. One container per named profile (sorted alphabetically, run after `init-hermes`): profile create (`--clone` when set) → config → workspace → dotenv → plugins → skills → bundles → crons. Each profile's dotenv volume mounts attach only to its own container.

### Ordering semantics preserved
- `init-chown-data` (optional) → `init-hermes` → `init-profile-<name>` → `init-searxng-config` → user `initScripts` / `initContainers`
- Default profile is fully configured before profile containers run, so `--clone` copies complete state
- All scripts keep their manifest-based idempotent skip logic

## Tradeoffs
- Failure attribution granularity decreases per step but improves per profile (`kubectl describe pod` shows `init-profile-coder` failed); step banners mitigate
- One rolling update for existing users on upgrade (pod template changes)

## Test plan
- [x] `make test` — controller + usecase suites pass
- [x] `make lint-fix` — 0 issues
- [x] `make manifests generate` + `make build-installer` — CRD/install.yaml/chart regenerated
- [x] New tests: `TestConsolidatedInitContainers`, `TestBuildProfilesCleanupScript`, `TestBuildProfileCreationScript`, `TestCombineInitSteps`