### PR TITLE
chore: disable heartbeat for local runs via make run

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -115,7 +115,7 @@ build: manifests generate fmt vet ## Build manager binary.
 
 .PHONY: run
 run: manifests generate fmt vet ## Run a controller from your host.
-	go run ./cmd/main.go
+	go run ./cmd/main.go --heartbeat-disabled
 
 # If you wish to build the manager image targeting other platforms you can use the --platform flag.
 # (i.e. docker build --platform linux/arm64). However, you must enable docker buildKit for it.


### PR DESCRIPTION
Pass `--heartbeat-disabled` in the `make run` target so the manager uses the noop heartbeat sender and no anonymous PostHog events are sent during local development.