### PR TITLE
docs: drop snapshot behavior notes, keep snapshot inspection commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,24 +185,17 @@ hermes:
       volumeSnapshotClassName: my-class  # optional; omit to use the cluster default
 ```
 
-**Behavior:**
+Retained snapshots are listed in `status.snapshot`:
 
-- Cron-scheduled; if runs were missed, exactly one catch-up snapshot is taken. Skipped while [`suspend`ed](#suspend).
-- Named `<pvc>-<yyyymmddhhmmss>`, labeled `agents.hermeum.app/agent=<name>`, and **not owned by the agent** — deleting the HermesAgent never garbage-collects its backups.
-- Retention keeps the newest N snapshots and deletes the rest.
-- Retained snapshots are listed in `status.snapshot`:
+```sh
+kubectl get hermesagent my-agent -o jsonpath='{.status.snapshot}'
+```
 
-  ```sh
-  kubectl get hermesagent my-agent -o jsonpath='{.status.snapshot}'
-  ```
+To list the VolumeSnapshot objects of an agent directly:
 
-  To list the VolumeSnapshot objects of an agent directly:
-
-  ```sh
-  kubectl get volumesnapshots -l agents.hermeum.app/agent=my-agent
-  ```
-
-- Restoring from a snapshot is not yet supported (planned follow-up).
+```sh
+kubectl get volumesnapshots -l agents.hermeum.app/agent=my-agent
+```
 
 
 ### `hermes.workspace`


### PR DESCRIPTION
Trim the `snapshot` section of the README by removing the **Behavior:** bullet list (cron scheduling, naming/labeling, retention, restore caveat). The section now keeps only the commands for inspecting snapshots: `status.snapshot` via `kubectl` and listing VolumeSnapshots by label.