### PR TITLE
feat: add Ready condition for reconcile monitoring

### DIFF
--- a/api/v1alpha1/hermesagent_types.go
+++ b/api/v1alpha1/hermesagent_types.go
@@ -54,6 +54,10 @@ const (
 type HermesAgentConditionType string
 
 const (
+	// ConditionReady indicates whether the operator reconciled all managed
+	// resources successfully in the most recent reconcile pass. It reflects
+	// controller reconciliation, not workload health (see status.phase).
+	ConditionReady HermesAgentConditionType = "Ready"
 	// ConditionSnapshotUnsupported indicates that periodic snapshots are
 	// configured but the cluster cannot support them (e.g. the VolumeSnapshot
 	// CRD or snapshot-controller is not installed).
@@ -1555,6 +1559,7 @@ type SnapshotRef struct {
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase"
+// +kubebuilder:printcolumn:name="Ready",type="string",JSONPath=".status.conditions[?(@.type=='Ready')].status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp"
 
 // HermesAgent is the Schema for the hermesagents API

--- a/config/crd/bases/agents.hermeum.app_hermesagents.yaml
+++ b/config/crd/bases/agents.hermeum.app_hermesagents.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date

--- a/internal/usecase/hermesagent_conditions.go
+++ b/internal/usecase/hermesagent_conditions.go
@@ -1,0 +1,64 @@
+package usecase
+
+import (
+	"context"
+
+	agentsv1alpha1 "hermeum/hermes-agent-operator/api/v1alpha1"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// Reconciliation reasons for the Ready condition, one per resource reconcile
+// loop so the failing loop is identifiable from the condition alone.
+const (
+	condReasonReconcileSucceeded    = "ReconcileSucceeded"
+	condReasonHermesConfigMapFailed = "HermesConfigMapReconcileFailed"
+	condReasonHermesSecretFailed    = "HermesSecretReconcileFailed"
+	condReasonSearXNGConfigMapFail  = "SearXNGConfigMapReconcileFailed"
+	condReasonSearXNGSecretFailed   = "SearXNGSecretReconcileFailed"
+	condReasonServiceAccountFailed  = "ServiceAccountReconcileFailed"
+	condReasonRoleFailed            = "RoleReconcileFailed"
+	condReasonServiceFailed         = "ServiceReconcileFailed"
+	condReasonIngressFailed         = "IngressReconcileFailed"
+	condReasonNetworkPolicyFailed   = "NetworkPolicyReconcileFailed"
+	condReasonStatefulSetFailed     = "StatefulSetReconcileFailed"
+)
+
+// markReady sets the Ready condition to True with reason ReconcileSucceeded
+// and reports whether the status changed. The caller is responsible for
+// persisting the status.
+func (u *HermesAgentUseCase) markReady(ctx context.Context, ha *agentsv1alpha1.HermesAgent) bool {
+	changed := setReadyCondition(ha, metav1.ConditionTrue, condReasonReconcileSucceeded, "Reconciled all managed resources")
+	if changed {
+		u.tel.Info(ctx, "HermesAgent reconciled successfully")
+	}
+	return changed
+}
+
+// markReconcileFailed sets the Ready condition to False with the failing
+// loop's reason and persists the status best-effort. It always returns the
+// original reconcile error so a failing status write never masks it.
+func (u *HermesAgentUseCase) markReconcileFailed(ctx context.Context, ha *agentsv1alpha1.HermesAgent, reason string, reconcileErr error) error {
+	changed := setReadyCondition(ha, metav1.ConditionFalse, reason, reconcileErr.Error())
+	if !changed {
+		return reconcileErr
+	}
+	u.tel.Error(ctx, reconcileErr, "Reconciliation failed", "reason", reason)
+	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
+		u.tel.Error(ctx, err, "Could not update Ready condition after reconcile failure")
+	}
+	return reconcileErr
+}
+
+// setReadyCondition sets (or updates) the Ready condition and reports whether
+// anything changed.
+func setReadyCondition(ha *agentsv1alpha1.HermesAgent, status metav1.ConditionStatus, reason, message string) bool {
+	return meta.SetStatusCondition(&ha.Status.Conditions, metav1.Condition{
+		Type:               string(agentsv1alpha1.ConditionReady),
+		Status:             status,
+		ObservedGeneration: ha.Generation,
+		Reason:             reason,
+		Message:            message,
+	})
+}

--- a/internal/usecase/hermesagent_conditions_test.go
+++ b/internal/usecase/hermesagent_conditions_test.go
@@ -1,0 +1,202 @@
+package usecase
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	agentsv1alpha1 "hermeum/hermes-agent-operator/api/v1alpha1"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// failingConfigMapKube fails ConfigMap creation and records every status write.
+type failingConfigMapKube struct {
+	fakeSnapshotKube
+	getErr      error
+	createErr   error
+	statusErr   error
+	statusCalls int
+}
+
+func (f *failingConfigMapKube) GetConfigMap(ctx context.Context, param GetConfigMapParam) (*corev1.ConfigMap, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return nil, nil
+}
+
+func (f *failingConfigMapKube) CreateConfigMapOwnedByHermesAgent(ctx context.Context, param CreateConfigMapOfHermesAgentParam) error {
+	return f.createErr
+}
+
+func (f *failingConfigMapKube) UpdateHermesAgentStatus(ctx context.Context, param UpdateHermesAgentStatusParam) error {
+	f.statusCalls++
+	if f.statusErr != nil {
+		return f.statusErr
+	}
+	return nil
+}
+
+// readyCondition returns the Ready condition of the agent, or nil.
+func readyCondition(ha *agentsv1alpha1.HermesAgent) *metav1.Condition {
+	return meta.FindStatusCondition(ha.Status.Conditions, string(agentsv1alpha1.ConditionReady))
+}
+
+func TestReconcileHermesConfigMap_FailureSetsReadyCondition(t *testing.T) {
+	ctx := context.Background()
+	createErr := errors.New("forbidden")
+	kube := &failingConfigMapKube{createErr: createErr}
+	uc := NewHermesAgentUseCase(kube, silentTelemetry{})
+
+	ha := minimalHA()
+	result, err := uc.reconcileHermesConfigMap(ctx, ha)
+	if err == nil {
+		t.Fatal("expected the original reconcile error to be returned")
+	}
+	if !errors.Is(err, createErr) {
+		t.Errorf("expected original error, got %v", err)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected 30s requeue, got %v", result.RequeueAfter)
+	}
+
+	cond := readyCondition(ha)
+	if cond == nil {
+		t.Fatal("expected Ready condition")
+	}
+	if cond.Status != metav1.ConditionFalse {
+		t.Errorf("expected Ready=False, got %s", cond.Status)
+	}
+	if cond.Reason != condReasonHermesConfigMapFailed {
+		t.Errorf("expected reason %s, got %s", condReasonHermesConfigMapFailed, cond.Reason)
+	}
+	if cond.ObservedGeneration != ha.Generation {
+		t.Errorf("expected ObservedGeneration %d, got %d", ha.Generation, cond.ObservedGeneration)
+	}
+	if kube.statusCalls != 1 {
+		t.Errorf("expected 1 status write on first failure, got %d", kube.statusCalls)
+	}
+}
+
+func TestReconcileHermesConfigMap_RepeatedFailureDoesNotRewriteStatus(t *testing.T) {
+	ctx := context.Background()
+	kube := &failingConfigMapKube{createErr: errors.New("forbidden")}
+	uc := NewHermesAgentUseCase(kube, silentTelemetry{})
+
+	ha := minimalHA()
+	for range 3 {
+		if _, err := uc.reconcileHermesConfigMap(ctx, ha); err == nil {
+			t.Fatal("expected error")
+		}
+	}
+	if kube.statusCalls != 1 {
+		t.Errorf("expected 1 status write across repeated identical failures, got %d", kube.statusCalls)
+	}
+}
+
+func TestReconcileHermesConfigMap_StatusWriteFailureReturnsOriginalError(t *testing.T) {
+	ctx := context.Background()
+	createErr := errors.New("forbidden")
+	kube := &failingConfigMapKube{
+		createErr: createErr,
+		statusErr: errors.New("conflict"),
+	}
+	uc := NewHermesAgentUseCase(kube, silentTelemetry{})
+
+	ha := minimalHA()
+	_, err := uc.reconcileHermesConfigMap(ctx, ha)
+	if !errors.Is(err, createErr) {
+		t.Errorf("expected the original reconcile error, got %v", err)
+	}
+	if errors.Is(err, kube.statusErr) {
+		t.Error("status write failure must not mask the original error")
+	}
+}
+
+func TestReconcileStatefulSet_SetstReadyTrueOnSuccess(t *testing.T) {
+	ctx := context.Background()
+	kube := &fakeSnapshotKube{}
+	uc := NewHermesAgentUseCase(kube, silentTelemetry{})
+
+	ha := minimalHA()
+	// minimalHA has no RBAC service account name, so deriveStatus's GetPod
+	// returns nil (pod missing → Pending) but reconciliation still succeeds.
+	result, err := uc.reconcileStatefulSet(ctx, ha)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.RequeueAfter != 10*time.Second {
+		t.Errorf("expected 10s requeue for pending phase, got %v", result.RequeueAfter)
+	}
+
+	cond := readyCondition(ha)
+	if cond == nil {
+		t.Fatal("expected Ready condition")
+	}
+	if cond.Status != metav1.ConditionTrue {
+		t.Errorf("expected Ready=True, got %s", cond.Status)
+	}
+	if cond.Reason != condReasonReconcileSucceeded {
+		t.Errorf("expected reason %s, got %s", condReasonReconcileSucceeded, cond.Reason)
+	}
+	if len(kube.statuses) != 1 {
+		t.Errorf("expected exactly 1 status write, got %d", len(kube.statuses))
+	}
+}
+
+func TestReconcileStatefulSet_FailureSetsReadyCondition(t *testing.T) {
+	ctx := context.Background()
+	getErr := apierrors.NewNotFound(schema.GroupResource{Group: "apps", Resource: "statefulsets"}, "x")
+	kube := &failingStatefulSetKube{getErr: getErr}
+	uc := NewHermesAgentUseCase(kube, silentTelemetry{})
+
+	ha := minimalHA()
+	_, err := uc.reconcileStatefulSet(ctx, ha)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+
+	cond := readyCondition(ha)
+	if cond == nil {
+		t.Fatal("expected Ready condition")
+	}
+	if cond.Status != metav1.ConditionFalse || cond.Reason != condReasonStatefulSetFailed {
+		t.Errorf("unexpected condition: %+v", cond)
+	}
+}
+
+// failingStatefulSetKube fails StatefulSet lookups.
+type failingStatefulSetKube struct {
+	fakeSnapshotKube
+	getErr error
+}
+
+func (f *failingStatefulSetKube) GetStatefulSet(ctx context.Context, param GetStatefulSetParam) (*appsv1.StatefulSet, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+	return nil, nil
+}
+
+func TestSetReadyCondition_ChangeDetection(t *testing.T) {
+	ha := minimalHA()
+
+	if setReadyCondition(ha, metav1.ConditionTrue, condReasonReconcileSucceeded, "msg") != true {
+		t.Error("first set must report changed")
+	}
+	// Identical set must report unchanged (no redundant status writes).
+	if setReadyCondition(ha, metav1.ConditionTrue, condReasonReconcileSucceeded, "msg") != false {
+		t.Error("identical condition must report unchanged")
+	}
+	// Only the reason changing must report changed.
+	if setReadyCondition(ha, metav1.ConditionTrue, condReasonHermesConfigMapFailed, "msg") != true {
+		t.Error("reason change must report changed")
+	}
+}

--- a/internal/usecase/hermesagent_hermes_configmap.go
+++ b/internal/usecase/hermesagent_hermes_configmap.go
@@ -17,7 +17,13 @@ import (
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
-func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) reconcileHermesConfigMap(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (result ctrl.Result, err error) {
+	defer func() {
+		if err != nil {
+			err = u.markReconcileFailed(ctx, ha, condReasonHermesConfigMapFailed, err)
+		}
+	}()
+
 	cmName := ha.GetHermesName()
 	cm, err := u.kube.GetConfigMap(ctx, GetConfigMapParam{
 		NamespacedName: types.NamespacedName{Name: cmName, Namespace: ha.Namespace},

--- a/internal/usecase/hermesagent_hermes_secret.go
+++ b/internal/usecase/hermesagent_hermes_secret.go
@@ -32,7 +32,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) reconcileHermesSecret(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (result ctrl.Result, err error) {
+	defer func() {
+		if err != nil {
+			err = u.markReconcileFailed(ctx, ha, condReasonHermesSecretFailed, err)
+		}
+	}()
+
 	secretNsName := types.NamespacedName{Name: ha.GetHermesName(), Namespace: ha.Namespace}
 
 	existing, err := u.kube.GetSecret(ctx, GetSecretParam{NamespacedName: secretNsName})

--- a/internal/usecase/hermesagent_ingress.go
+++ b/internal/usecase/hermesagent_ingress.go
@@ -14,7 +14,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) reconcileIngress(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (result ctrl.Result, err error) {
+	defer func() {
+		if err != nil {
+			err = u.markReconcileFailed(ctx, ha, condReasonIngressFailed, err)
+		}
+	}()
+
 	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
 
 	existing, err := u.kube.GetIngress(ctx, GetIngressParam{NamespacedName: nsName})

--- a/internal/usecase/hermesagent_networkpolicy.go
+++ b/internal/usecase/hermesagent_networkpolicy.go
@@ -17,7 +17,13 @@ import (
 
 const namespaceNameLabel = "kubernetes.io/metadata.name"
 
-func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) reconcileNetworkPolicy(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (result ctrl.Result, err error) {
+	defer func() {
+		if err != nil {
+			err = u.markReconcileFailed(ctx, ha, condReasonNetworkPolicyFailed, err)
+		}
+	}()
+
 	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
 
 	existing, err := u.kube.GetNetworkPolicy(ctx, GetNetworkPolicyParam{NamespacedName: nsName})

--- a/internal/usecase/hermesagent_role.go
+++ b/internal/usecase/hermesagent_role.go
@@ -13,7 +13,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) reconcileRole(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (result ctrl.Result, err error) {
+	defer func() {
+		if err != nil {
+			err = u.markReconcileFailed(ctx, ha, condReasonRoleFailed, err)
+		}
+	}()
+
 	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
 
 	existingRole, err := u.kube.GetRole(ctx, GetRoleParam{NamespacedName: nsName})

--- a/internal/usecase/hermesagent_searxng_configmap.go
+++ b/internal/usecase/hermesagent_searxng_configmap.go
@@ -12,7 +12,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) reconcileSearXNGConfigMap(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (result ctrl.Result, err error) {
+	defer func() {
+		if err != nil {
+			err = u.markReconcileFailed(ctx, ha, condReasonSearXNGConfigMapFail, err)
+		}
+	}()
+
 	cmNsName := types.NamespacedName{Name: ha.GetSearXNGName(), Namespace: ha.Namespace}
 
 	existing, err := u.kube.GetConfigMap(ctx, GetConfigMapParam{NamespacedName: cmNsName})

--- a/internal/usecase/hermesagent_searxng_secret.go
+++ b/internal/usecase/hermesagent_searxng_secret.go
@@ -14,7 +14,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) reconcileSearXNGSecret(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (result ctrl.Result, err error) {
+	defer func() {
+		if err != nil {
+			err = u.markReconcileFailed(ctx, ha, condReasonSearXNGSecretFailed, err)
+		}
+	}()
+
 	secretNsName := types.NamespacedName{Name: ha.GetSearXNGName(), Namespace: ha.Namespace}
 
 	existing, err := u.kube.GetSecret(ctx, GetSecretParam{NamespacedName: secretNsName})

--- a/internal/usecase/hermesagent_service.go
+++ b/internal/usecase/hermesagent_service.go
@@ -15,7 +15,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) reconcileService(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (result ctrl.Result, err error) {
+	defer func() {
+		if err != nil {
+			err = u.markReconcileFailed(ctx, ha, condReasonServiceFailed, err)
+		}
+	}()
+
 	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
 
 	existing, err := u.kube.GetService(ctx, GetServiceParam{NamespacedName: nsName})

--- a/internal/usecase/hermesagent_serviceaccount.go
+++ b/internal/usecase/hermesagent_serviceaccount.go
@@ -13,7 +13,13 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
-func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) reconcileServiceAccount(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (result ctrl.Result, err error) {
+	defer func() {
+		if err != nil {
+			err = u.markReconcileFailed(ctx, ha, condReasonServiceAccountFailed, err)
+		}
+	}()
+
 	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
 
 	existing, err := u.kube.GetServiceAccount(ctx, GetServiceAccountParam{NamespacedName: nsName})

--- a/internal/usecase/hermesagent_statefulset.go
+++ b/internal/usecase/hermesagent_statefulset.go
@@ -40,7 +40,13 @@ const (
 // is disabled or moved to another port.
 var hermesHealthCheckCommand = []string{"hermes", "gateway", "status"}
 
-func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
+func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (result ctrl.Result, err error) {
+	defer func() {
+		if err != nil {
+			err = u.markReconcileFailed(ctx, ha, condReasonStatefulSetFailed, err)
+		}
+	}()
+
 	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
 
 	sts, err := u.kube.GetStatefulSet(ctx, GetStatefulSetParam{
@@ -97,6 +103,10 @@ func (u *HermesAgentUseCase) reconcileStatefulSet(ctx context.Context, ha *agent
 
 	ha.Status.ManagedResources.StatefulSet = ha.Name
 	ha.Status.Phase, ha.Status.Reason = u.deriveStatus(ctx, ha)
+	// The StatefulSet loop runs after every other resource loop, so reaching
+	// this point means all managed resources reconciled. Workload readiness
+	// itself is tracked by status.phase, not by this condition.
+	u.markReady(ctx, ha)
 	if err := u.kube.UpdateHermesAgentStatus(ctx, UpdateHermesAgentStatusParam{HermesAgent: ha}); err != nil {
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}

--- a/skills/hermes-agent-operator/crd.yaml
+++ b/skills/hermes-agent-operator/crd.yaml
@@ -18,6 +18,9 @@ spec:
     - jsonPath: .status.phase
       name: Phase
       type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date


### PR DESCRIPTION
## Summary
- Adds a single top-level `Ready` condition to HermesAgent status so monitors can see reconciliation health at a glance, instead of relying only on controller logs/metrics.
- Each resource reconcile loop (Hermes/SearXNG ConfigMaps & Secrets, ServiceAccount, Role, Service, Ingress, NetworkPolicy, StatefulSet) sets the condition inline:
  - **Failure**: `Ready=False` with a loop-specific reason (e.g. `ServiceReconcileFailed`, `HermesSecretReconcileFailed`) and the error message. The status write is best-effort and never masks the original reconcile error; identical repeated failures do not re-write status.
  - **Success**: the StatefulSet loop — which runs after every other mandatory resource — sets `Ready=True` with reason `ReconcileSucceeded`.
- Workload health remains in `status.phase`/`reason`; the snapshot loop keeps its dedicated `SnapshotUnsupported` condition (snapshots are best-effort and do not affect `Ready`).
- Adds a `Ready` printcolumn to the HermesAgent CRD (`make manifests generate` applied).

## Implementation notes
- New `internal/usecase/hermesagent_conditions.go`: `markReady`, `markReconcileFailed`, `setReadyCondition` + per-loop reason constants, following the existing `setSnapshotUnsupported` pattern.
- Each loop uses a named-return + `defer` guard, so condition logic lives in the loops themselves (no changes to `Reconcile` orchestration in `hermesagent.go`).
- New tests in `internal/usecase/hermesagent_conditions_test.go` cover: failure sets the condition with the right reason/generation and one status write, repeated identical failures cause no extra writes, status-write failure returns the original error, StatefulSet success sets `Ready=True` with exactly one status write, and condition change detection.

## Verification
- `go test ./internal/usecase/ ./internal/controller/` ✅
- `make lint-fix` ✅ (0 issues)
- `make manifests generate` ✅ (Ready column in CRD + skills copy)