### PR TITLE
fix: mount-first restore reshape and retention exemption for restore source

### DIFF
--- a/internal/usecase/hermesagent_restore.go
+++ b/internal/usecase/hermesagent_restore.go
@@ -38,9 +38,12 @@ var volumeSnapshotAPIGroupPtr = func() *string {
 // the desired state is "the data volume is the PVC restored from this
 // snapshot", and every reconcile converges to it.
 //
-//   - the snapshot must exist in the agent's namespace and be ReadyToUse;
-//     otherwise a RestoreFailed condition is surfaced and the reconcile
-//     requeues, leaving the agent on its current volume;
+//   - the snapshot must exist in the agent's namespace and be ReadyToUse —
+//     but only while the restored PVC does not exist yet. Once provisioned,
+//     the PVC is the desired state and the source snapshot is no longer
+//     consulted: it may be deleted (e.g. by retention) without affecting the
+//     restored volume. A missing snapshot still surfaces a RestoreFailed
+//     condition and requeues, leaving the agent on its current volume;
 //   - the restored PVC is named <snapshot>-restore, created with the
 //     snapshot as its dataSource, sized from the snapshot's restoreSize,
 //     and owned by the agent. Provisioning happens while the agent keeps
@@ -48,7 +51,10 @@ var volumeSnapshotAPIGroupPtr = func() *string {
 //   - the StatefulSet volumeClaimTemplate is immutable, so an
 //     empty-PVC-shaped StatefulSet is deleted once (a rolling update then
 //     cannot reshape it); the next reconcile recreates it mounting the
-//     restored PVC via an explicit volume;
+//     restored PVC via an explicit volume. The reshape does not wait for
+//     the PVC to bind: on a WaitForFirstConsumer storage class the PVC
+//     only binds once a pod mounts it, so the agent pod is expected to be
+//     the first consumer;
 //   - previous volumes are left in place; cleaning them up is the user's
 //     responsibility. The snapshot itself is never modified or deleted.
 func (u *HermesAgentUseCase) reconcileRestore(ctx context.Context, ha *agentsv1alpha1.HermesAgent) (ctrl.Result, error) {
@@ -64,14 +70,6 @@ func (u *HermesAgentUseCase) reconcileRestore(ctx context.Context, ha *agentsv1a
 	}
 
 	nsName := types.NamespacedName{Namespace: ha.Namespace, Name: ha.Name}
-	sourceSnapshot, err := u.getReadySnapshot(ctx, ha, source)
-	if err != nil {
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
-	}
-	if sourceSnapshot == nil {
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	}
-
 	restoredPVCName := buildRestoredPVCName(source)
 
 	// Provision the restore PVC from the snapshot while the agent keeps
@@ -83,6 +81,13 @@ func (u *HermesAgentUseCase) reconcileRestore(ctx context.Context, ha *agentsv1a
 		return ctrl.Result{RequeueAfter: 30 * time.Second}, err
 	}
 	if restored == nil {
+		sourceSnapshot, err := u.getReadySnapshot(ctx, ha, source)
+		if err != nil {
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, err
+		}
+		if sourceSnapshot == nil {
+			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+		}
 		desired := buildRestoredPVC(ha, sourceSnapshot)
 		if err := u.kube.CreatePersistentVolumeClaimOwnedByHermesAgent(ctx, CreatePersistentVolumeClaimOfHermesAgentParam{
 			HermesAgent:           ha,
@@ -100,10 +105,6 @@ func (u *HermesAgentUseCase) reconcileRestore(ctx context.Context, ha *agentsv1a
 		if restored == nil {
 			return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 		}
-	}
-	if restored.Status.Phase != corev1.ClaimBound {
-		u.tel.Info(ctx, "Waiting for restore PVC to bind", "name", restoredPVCName)
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	// Reshape gate (forward-only): an existing StatefulSet carries the

--- a/internal/usecase/hermesagent_restore_test.go
+++ b/internal/usecase/hermesagent_restore_test.go
@@ -230,6 +230,16 @@ func (f *fakeRestoreKube) DeleteVolumeSnapshot(ctx context.Context, param Delete
 	return nil
 }
 
+// pendingPVC returns a PVC that exists but is not yet bound (the shape a
+// PVC has on a WaitForFirstConsumer storage class before its first
+// consumer mounts it).
+func pendingPVC(name string) *corev1.PersistentVolumeClaim {
+	return &corev1.PersistentVolumeClaim{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default"},
+		Status:     corev1.PersistentVolumeClaimStatus{Phase: corev1.ClaimPending},
+	}
+}
+
 // restoreHA builds a HermesAgent with persistence (enabled PVC) and an
 // existingSnapshot source.
 func restoreHA(source string) *agentsv1alpha1.HermesAgent {
@@ -390,34 +400,27 @@ func TestReconcileRestore_ProvisionsPVCWhileAgentRuns(t *testing.T) {
 	uc := NewHermesAgentUseCase(kube, silentTelemetry{})
 	ha := restoreHA(restoreSourceSnapshot)
 
-	// First reconcile: the restore PVC is created (unbound) while the old
-	// volume, pod, and StatefulSet are untouched.
-	if _, err := uc.reconcileRestore(ctx, ha); err != nil {
+	// First reconcile: the restore PVC is created and the reshape starts in
+	// the same pass — the VCT-shaped StatefulSet is deleted immediately
+	// (mount-first: on a WaitForFirstConsumer storage class the PVC only
+	// binds once the recreated pod mounts it, so waiting for Bound would
+	// deadlock). The old data PVC is left in place.
+	result, err := uc.reconcileRestore(ctx, ha)
+	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	assertRestoredPVC(t, kube, restoreSourceSnapshot, "15Gi")
-	if kube.stsDeletes != 0 {
-		t.Error("StatefulSet must not be deleted before the restore PVC is bound")
+	if kube.stsDeletes != 1 {
+		t.Errorf("expected StatefulSet deleted once in the same pass as provisioning, got %d", kube.stsDeletes)
+	}
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected requeue after reshape, got %v", result)
 	}
 	if _, ok := kube.pvcs[restoreOldPVCName]; !ok {
 		t.Error("the old data PVC must be left in place")
 	}
 
-	// PVC binds; second reconcile reshapes: deletes the VCT-shaped
-	// StatefulSet once so the next pass recreates it with the explicit volume.
-	kube.pvcs[restoreRestoredPVC].Status.Phase = corev1.ClaimBound
-	result, err := uc.reconcileRestore(ctx, ha)
-	if err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
-	if result.RequeueAfter != 30*time.Second {
-		t.Errorf("expected requeue after reshape, got %v", result)
-	}
-	if kube.stsDeletes != 1 {
-		t.Errorf("expected StatefulSet deleted once, got %d", kube.stsDeletes)
-	}
-
-	// Third reconcile: no StatefulSet, nothing left to do — zero result lets
+	// Second reconcile: no StatefulSet, nothing left to do — zero result lets
 	// reconcileStatefulSet recreate it with the restored volume.
 	result, err = uc.reconcileRestore(ctx, ha)
 	if err != nil {
@@ -441,27 +444,78 @@ func TestReconcileRestore_ProvisionsPVCWhileAgentRuns(t *testing.T) {
 	}
 }
 
-func TestReconcileRestore_UnboundPVCRequeues(t *testing.T) {
+func TestReconcileRestore_PendingPVCStillReshapes(t *testing.T) {
+	// WaitForFirstConsumer contract: the restore PVC binds only when a pod
+	// mounts it, so the reshape must not wait for ClaimBound. A pending PVC
+	// with a VCT-shaped StatefulSet must still trigger the one-time delete;
+	// reconcileStatefulSet recreates the StatefulSet mounting the restored
+	// volume, and the agent pod becomes the first consumer.
 	ctx := context.Background()
 	kube := newFakeRestoreKube()
 	kube.snapshots[simpleSnapshot] = readySnapshot(simpleSnapshot, "10Gi")
+	// The restored PVC exists but is Pending.
+	kube.pvcs[simpleRestoredPVC] = pendingPVC(simpleRestoredPVC)
 	kube.sts = vctStatefulSet()
 	uc := NewHermesAgentUseCase(kube, silentTelemetry{})
 	ha := restoreHA(simpleSnapshot)
 
-	// PVC created but pending: no teardown, no completion.
-	if _, err := uc.reconcileRestore(ctx, ha); err != nil {
-		t.Fatalf("unexpected error: %v", err)
-	}
 	result, err := uc.reconcileRestore(ctx, ha)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.RequeueAfter != 30*time.Second {
-		t.Errorf("expected 30s requeue while unbound, got %v", result.RequeueAfter)
+	if kube.stsDeletes != 1 {
+		t.Errorf("expected StatefulSet deleted once despite pending PVC, got %d", kube.stsDeletes)
 	}
-	if kube.stsDeletes != 0 {
-		t.Error("StatefulSet must not be deleted while the restore PVC is unbound")
+	if result.RequeueAfter != 30*time.Second {
+		t.Errorf("expected requeue after reshape, got %v", result)
+	}
+
+	// Next pass: StatefulSet gone, restore converged, no further churn.
+	result, err = uc.reconcileRestore(ctx, ha)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsZero() {
+		t.Errorf("expected zero result, got %v", result)
+	}
+	if kube.stsDeletes != 1 {
+		t.Errorf("restore must be idempotent, stsDeletes=%d", kube.stsDeletes)
+	}
+}
+
+func TestReconcileRestore_IgnoresSourceSnapshotOncePVExists(t *testing.T) {
+	// The restored PVC is the desired state: once it exists, the source
+	// snapshot may be gone (e.g. pruned by retention) without failing the
+	// restore or blocking the reshape.
+	ctx := context.Background()
+	kube := newFakeRestoreKube()
+	// No snapshot in the fake at all.
+	kube.pvcs[simpleRestoredPVC] = pendingPVC(simpleRestoredPVC)
+	kube.sts = vctStatefulSet()
+	uc := NewHermesAgentUseCase(kube, silentTelemetry{})
+	ha := restoreHA(simpleSnapshot)
+
+	result, err := uc.reconcileRestore(ctx, ha)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if kube.stsDeletes != 1 {
+		t.Errorf("expected StatefulSet deleted once, got %d", kube.stsDeletes)
+	}
+	cond := meta.FindStatusCondition(ha.Status.Conditions, string(agentsv1alpha1.ConditionRestoreFailed))
+	if cond != nil {
+		t.Errorf("no RestoreFailed condition expected once the PVC exists, got %+v", cond)
+	}
+	_ = result
+
+	// And with the PVC bound and no StatefulSet: clean zero result.
+	kube.pvcs[simpleRestoredPVC] = boundPVC(simpleRestoredPVC)
+	result, err = uc.reconcileRestore(ctx, ha)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !result.IsZero() {
+		t.Errorf("expected zero result, got %v", result)
 	}
 }
 

--- a/internal/usecase/hermesagent_snapshot.go
+++ b/internal/usecase/hermesagent_snapshot.go
@@ -132,6 +132,18 @@ func (u *HermesAgentUseCase) reconcileSnapshot(ctx context.Context, ha *agentsv1
 
 	_, deprecated := splitSnapshots(snapshots, snap.GetRetention())
 
+	// The snapshot referenced by persistence.existingSnapshot is the live
+	// restore source: retention must never delete it.
+	if source := ha.GetHermes().GetPersistence().GetExistingSnapshot(); source != "" {
+		pruned := deprecated[:0]
+		for _, snap := range deprecated {
+			if snap.Name != source {
+				pruned = append(pruned, snap)
+			}
+		}
+		deprecated = pruned
+	}
+
 	// Delete outdated snapshots beyond the retention window.
 	for _, old := range deprecated {
 		if err := u.kube.DeleteVolumeSnapshot(ctx, DeleteVolumeSnapshotParam{

--- a/internal/usecase/hermesagent_snapshot_test.go
+++ b/internal/usecase/hermesagent_snapshot_test.go
@@ -468,7 +468,7 @@ func TestReconcileSnapshot_RetentionKeepsNewest(t *testing.T) {
 	kube := &fakeSnapshotKube{
 		pvc: boundPVC("hermes-data-test-0"),
 		snapshots: []VolumeSnapshot{
-			snapshotObj("hermes-data-test-0-20260901030000", time.Date(2026, 9, 1, 3, 0, 0, 0, time.UTC)),
+			snapshotObj(retentionExpiredSnapshot, time.Date(2026, 9, 1, 3, 0, 0, 0, time.UTC)),
 			snapshotObj("hermes-data-test-0-20260902030000", time.Date(2026, 9, 2, 3, 0, 0, 0, time.UTC)),
 			snapshotObj("hermes-data-test-0-20260903030000", time.Date(2026, 9, 3, 3, 0, 0, 0, time.UTC)),
 		},
@@ -484,9 +484,42 @@ func TestReconcileSnapshot_RetentionKeepsNewest(t *testing.T) {
 	if len(kube.deleted) != 1 {
 		t.Fatalf("expected 1 deletion, got %d: %v", len(kube.deleted), kube.deleted)
 	}
-	if kube.deleted[0].Name != "hermes-data-test-0-20260901030000" {
+	if kube.deleted[0].Name != retentionExpiredSnapshot {
 		t.Errorf("expected oldest snapshot deleted, got %q", kube.deleted[0].Name)
 	}
+}
+
+func TestReconcileSnapshot_RetentionNeverDeletesRestoreSource(t *testing.T) {
+	ctx := context.Background()
+	retention := 2
+	kube := &fakeSnapshotKube{
+		pvc: boundPVC("hermes-data-test-0"),
+		snapshots: []VolumeSnapshot{
+			snapshotObj(retentionExpiredSnapshot, time.Date(2026, 9, 1, 3, 0, 0, 0, time.UTC)),
+			snapshotObj("hermes-data-test-0-20260902030000", time.Date(2026, 9, 2, 3, 0, 0, 0, time.UTC)),
+			snapshotObj("hermes-data-test-0-20260903030000", time.Date(2026, 9, 3, 3, 0, 0, 0, time.UTC)),
+		},
+	}
+	uc := NewHermesAgentUseCase(kube, silentTelemetry{})
+
+	ha := snapshotHA(&retention, "0 3 * * *")
+	// The restore source is the oldest snapshot, already outside the
+	// retention window: retention must skip it.
+	ha.Spec.Hermes.Storage.Persistence.ExistingSnapshot = ptrString(retentionExpiredSnapshot)
+	// Schedule far in the future so only retention runs.
+	ha.Status.Snapshot.LastScheduleTime = &metav1.Time{Time: time.Now().Add(-time.Hour)}
+	if _, err := uc.reconcileSnapshot(ctx, ha); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(kube.deleted) != 0 {
+		t.Errorf("no snapshot must be deleted when the only expired one is the restore source, got %v", kube.deleted)
+	}
+	for _, snap := range kube.snapshots {
+		if snap.Name == retentionExpiredSnapshot {
+			return
+		}
+	}
+	t.Error("restore source snapshot must be preserved")
 }
 
 func TestBuildDataPVCName(t *testing.T) {
@@ -535,6 +568,10 @@ const (
 	snapshotNameOld    = "old"
 	snapshotNameMiddle = "middle"
 	snapshotNameNew    = "new"
+
+	// retentionExpiredSnapshot is the oldest snapshot in the retention
+	// tests (Sep 1 03:00) — the one retention expires first.
+	retentionExpiredSnapshot = "hermes-data-test-0-20260901030000"
 )
 
 func TestSplitSnapshots(t *testing.T) {
@@ -660,7 +697,7 @@ func TestReconcileSnapshot_StatusTracksAllSnapshots(t *testing.T) {
 	kube := &fakeSnapshotKube{
 		pvc: boundPVC("hermes-data-test-0"),
 		snapshots: []VolumeSnapshot{
-			snapshotObj("hermes-data-test-0-20260901030000", time.Date(2026, 9, 1, 3, 0, 0, 0, time.UTC)),
+			snapshotObj(retentionExpiredSnapshot, time.Date(2026, 9, 1, 3, 0, 0, 0, time.UTC)),
 			snapshotObj("hermes-data-test-0-20260902030000", time.Date(2026, 9, 2, 3, 0, 0, 0, time.UTC)),
 		},
 	}
@@ -684,7 +721,7 @@ func TestReconcileSnapshot_StatusTracksAllSnapshots(t *testing.T) {
 	}
 	// Retention deleted the oldest live snapshot (Sep 1).
 	for _, ref := range ha.Status.Snapshot.Snapshots {
-		if ref.Name == "hermes-data-test-0-20260901030000" {
+		if ref.Name == retentionExpiredSnapshot {
 			t.Errorf("retention-expired snapshot %q still in status", ref.Name)
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes three defects in the restore-from-snapshot reconciler, all found and reproduced on a live cluster with a `WaitForFirstConsumer` storage class (the default on EKS/AKS/GKE and kind):

### 1. Bind deadlock in `reconcileRestore`
The reconciler waited for the restored PVC to reach `Bound` before reshaping the StatefulSet, but on a WFFC storage class a PVC only binds once a pod mounts it — and the only pod that could mount it is the agent itself, which the operator refused to roll until Bound. Circular wait: every restore stalled forever with `Waiting for restore PVC to bind`.

Fix: drop the Bound gate. The reshape proceeds as soon as the restore PVC is provisioned; the agent pod becomes the WFFC "first consumer" that triggers binding. This mirrors the normal (non-restore) path, which is mount-first by construction.

### 2. Source snapshot over-required after provisioning
`existingSnapshot` was validated (must exist + ReadyToUse) on every reconcile, forever — even after the restored PVC existed. Once retention pruned the source, a perfectly healthy agent got a permanent spurious `RestoreFailed` condition. (Also observed: a source deleted mid-restore lingers Terminating with `readyToUse=true`, which passed the readiness check while the CSI provisioner refused to use it.)

Fix: the source snapshot is consulted only while the restore PVC does not exist. Once provisioned, the PVC is the desired state; the snapshot may be deleted without affecting the restore.

### 3. Retention could delete the restore source
The snapshot prune loop treated the snapshot referenced by `existingSnapshot` like any other expired snapshot — deleting the very object the restore depends on.

Fix: retention never deletes the snapshot named by `persistence.existingSnapshot` for as long as it is referenced.

`hermesagent.go` (Reconcile ordering) is intentionally left unchanged: the early-return that suspends the snapshot loop while a restore is pending is kept as a deliberate guard.

## Test Plan
- [x] `go test ./...` — full suite green
- [x] `make lint` — 0 issues
- [x] Live cluster (kind, csi-driver-hostpath + external-snapshotter): stuck restore unblocked unattended by the fixed operator — PVC provisioned, StatefulSet reshaped, agent rolled onto the restored volume, marker file written before the snapshot present in the restored data
- [x] Retention cycling verified live: expired snapshots pruned, restore source exempted